### PR TITLE
[change] pathでエイリアスが使用できるように、webpack, jest, flowの設定を変更した

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,33 +6,21 @@
     "plugin:flowtype/recommended",
     "plugin:prettier/recommended"
   ],
-  "plugins": ["flowtype","jest"],
+  "plugins": ["flowtype", "jest"],
   "env": {
     "browser": true,
     "node": true,
     "jest": true
   },
   "rules": {
-    "flowtype/boolean-style": [
-      2,
-      "boolean"
-    ],
+    "flowtype/boolean-style": [2, "boolean"],
     "flowtype/define-flow-type": 1,
-    "flowtype/delimiter-dangle": [
-      2,
-      "never"
-    ],
-    "flowtype/generic-spacing": [
-      2,
-      "never"
-    ],
+    "flowtype/delimiter-dangle": [2, "never"],
+    "flowtype/generic-spacing": [2, "never"],
     "flowtype/no-primitive-constructor-types": 2,
     "flowtype/no-types-missing-file-annotation": 2,
     "flowtype/no-weak-types": 2,
-    "flowtype/object-type-delimiter": [
-      2,
-      "comma"
-    ],
+    "flowtype/object-type-delimiter": [2, "comma"],
     "flowtype/require-parameter-type": 1,
     "flowtype/require-return-type": [
       2,
@@ -42,32 +30,16 @@
       }
     ],
     "flowtype/require-valid-file-annotation": 2,
-    "flowtype/semi": [
-      2,
-      "always"
-    ],
-    "flowtype/space-after-type-colon": [
-      2,
-      "always"
-    ],
-    "flowtype/space-before-generic-bracket": [
-      2,
-      "never"
-    ],
-    "flowtype/space-before-type-colon": [
-      2,
-      "never"
-    ],
-    "flowtype/type-id-match": [
-      2,
-      "^([A-Z][a-z0-9]+)+Type$"
-    ],
-    "flowtype/union-intersection-spacing": [
-      2,
-      "always"
-    ],
+    "flowtype/semi": [2, "always"],
+    "flowtype/space-after-type-colon": [2, "always"],
+    "flowtype/space-before-generic-bracket": [2, "never"],
+    "flowtype/space-before-type-colon": [2, "never"],
+    "flowtype/type-id-match": [2, "^([A-Z][a-z0-9]+)+Type$"],
+    "flowtype/union-intersection-spacing": [2, "always"],
     "flowtype/use-flow-type": 1,
-    "flowtype/valid-syntax": 1
+    "flowtype/valid-syntax": 1,
+    "import/no-unresolved": 0,
+    "import/extensions": 0
   },
   "settings": {
     "flowtype": {

--- a/.flowconfig
+++ b/.flowconfig
@@ -7,5 +7,6 @@
 [lints]
 
 [options]
+module.name_mapper='^@components\(.*\)$' -> '<PROJECT_ROOT>/src/client/components\1'
 
 [strict]

--- a/package.json
+++ b/package.json
@@ -86,5 +86,10 @@
   "lint-staged": {
     "*.{js,jsx}": ["eslint --fix", "git add"],
     "*.{css,json,md}": ["prettier --write", "git add"]
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "@components(.*)$": "<rootDir>/src/client/components$1"
+    }
   }
 }

--- a/src/client/components/storybook/.eslintrc.json
+++ b/src/client/components/storybook/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": 0,
+    "flowtype/require-return-type": 0
+  }
+}

--- a/src/client/components/storybook/index.jsx
+++ b/src/client/components/storybook/index.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-
-import App from "../App";
+import App from "@components/App";
 
 // TODO: テスト実装のため、component作成時にこの例は削除する
 storiesOf("App", module).add("App.jsx", () => <App />);

--- a/src/client/components/storybook/webpack.config.js
+++ b/src/client/components/storybook/webpack.config.js
@@ -1,4 +1,11 @@
+const path = require("path");
+
 module.exports = {
+  resolve: {
+    alias: {
+      "@components": path.resolve(__dirname, "../")
+    }
+  },
   module: {
     rules: [
       {

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -2,7 +2,7 @@
 import io from "socket.io-client";
 import * as React from "react";
 import ReactDOM from "react-dom";
-import App from "./components/App";
+import App from "@components/App";
 
 const root = document.getElementById("root");
 if (root === null) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,10 @@ const config = {
     ]
   },
   resolve: {
-    extensions: [".jsx", ".js"]
+    extensions: [".jsx", ".js"],
+    alias: {
+      "@components": path.resolve(__dirname, "src/client/components")
+    }
   },
   plugins: [new HtmlWebpackPlugin(), new webpack.NamedModulesPlugin()]
 };


### PR DESCRIPTION
##  該当issue
【Raspberry Pi】pathでエイリアスを使用する #128

## 概略
- エイリアスを使用できるように設定を変更した
  - webpack.config.js
  - storybookで使用するwebpack.config.js
  - .flowconfig
  - jestの設定
- eslintのルールを変更
  - パスのルールを無効化