### PR TITLE
[add] components/atoms/MenuButtonを追加。testファイル追加。storybookに追加。

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
     "*.{css,json,md}": ["prettier --write", "git add"]
   },
   "jest": {
+    "setupTestFrameworkScriptFile": "./setupTests.js",
     "moduleNameMapper": {
+      "\\.(css|less)$": "identity-obj-proxy",
       "@components(.*)$": "<rootDir>/src/client/components$1"
     }
   }

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const enzyme = require("enzyme");
+const Adapter = require("enzyme-adapter-react-16");
+/* eslint-enable import/no-extraneous-dependencies */
+
+enzyme.configure({ adapter: new Adapter() });

--- a/src/client/components/atoms/MenuButton/index.jsx
+++ b/src/client/components/atoms/MenuButton/index.jsx
@@ -1,0 +1,25 @@
+// @flow
+import * as React from "react";
+import styles from "./style.css";
+
+type PropsType = {
+  children: string,
+  // flowのtype定義なのにreactのルールが適用されているので無効化
+  // eslint-disable-next-line react/require-default-props
+  selected?: string,
+  onButtonClick: () => void
+};
+
+function MenuButton(props: PropsType): React.Node {
+  const { selected } = props;
+  const className: string =
+    selected === "selected"
+      ? `${styles.button} ${styles.selected}`
+      : styles.button;
+  return (
+    <button className={className} onClick={props.onButtonClick}>
+      {props.children}
+    </button>
+  );
+}
+export default MenuButton;

--- a/src/client/components/atoms/MenuButton/style.css
+++ b/src/client/components/atoms/MenuButton/style.css
@@ -1,0 +1,22 @@
+@charset "utf-8";
+.button {
+  width: 100%;
+  height: 85px;
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  color: gray;
+  background: transparent;
+  border: none;
+  border-bottom: 1px dashed silver;
+  box-sizing: border-box;
+  transition: font-size 200ms;
+  outline: none;
+}
+.button.selected {
+  background-color: silver;
+  border: none;
+  color: white;
+  font-size: 24px;
+  font-weight: bold;
+}

--- a/src/client/components/storybook/index.jsx
+++ b/src/client/components/storybook/index.jsx
@@ -1,6 +1,18 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import App from "@components/App";
+import { action } from "@storybook/addon-actions";
 
-// TODO: テスト実装のため、component作成時にこの例は削除する
-storiesOf("App", module).add("App.jsx", () => <App />);
+// actions
+import MenuButton from "@components/atoms/MenuButton";
+
+// #region atoms
+storiesOf("Atoms/MenuButton", module)
+  .add("通常", () => (
+    <MenuButton onButtonClick={action("clicked")}>メニュー</MenuButton>
+  ))
+  .add("選択時", () => (
+    <MenuButton selected="selected" onButtonClick={action("clicked")}>
+      メニュー
+    </MenuButton>
+  ));
+// #endregion atoms

--- a/test/client/components/atoms/MenuButton/__snapshots__/index.test.jsx.snap
+++ b/test/client/components/atoms/MenuButton/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MenuButton.jsxのテスト スナップショット renders corecctly 1`] = `
+<button
+  className="button selected"
+  onClick={[Function]}
+>
+  メニュー
+</button>
+`;

--- a/test/client/components/atoms/MenuButton/index.test.jsx
+++ b/test/client/components/atoms/MenuButton/index.test.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import MenuButton from "@components/atoms/MenuButton";
+
+describe("MenuButton.jsxのテスト", () => {
+  const func = () => {};
+  describe("スナップショット", () => {
+    it("renders corecctly", () => {
+      const tree = renderer
+        .create(
+          <MenuButton selected="selected" onButtonClick={func}>
+            メニュー
+          </MenuButton>
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+  describe("コンポーネントのテスト", () => {
+    describe("子要素に「入退室処理」を指定して、ボタンをクリックした時", () => {
+      const onButtonClick = jest.fn();
+      const button = shallow(
+        <MenuButton onButtonClick={onButtonClick}>入退室処理</MenuButton>
+      );
+      button.find("button").simulate("click");
+      it("子要素は「入退室処理」である", () => {
+        expect(button.text()).toBe("入退室処理");
+      });
+      it("onButtonClickがコールされた", () => {
+        expect(onButtonClick).toHaveBeenCalled();
+      });
+    });
+    describe("selected属性を使用しない場合", () => {
+      const button = shallow(
+        <MenuButton onButtonClick={() => {}}>入退室処理</MenuButton>
+      );
+      it("classNameは「button」である", () => {
+        expect(button.props().className).toBe("button");
+      });
+    });
+    describe("selected属性を使用した場合", () => {
+      const button = shallow(
+        <MenuButton selected="selected" onButtonClick={() => {}}>
+          入退室処理
+        </MenuButton>
+      );
+      it("classNameは「button selected」である", () => {
+        expect(button.props().className).toBe("button selected");
+      });
+    });
+  });
+});


### PR DESCRIPTION
##  該当issue
【Raspberry Pi】[components作成] atoms/MenuButtonを作成 #129

## 概略
- MenuButtonコンポーネントを追加
- jestでcss modulesを有効化する設定を追加
- jestでenzymeを使用するため、setupTests.jsを追加
- テストコードをかいた
- storybookに登録した