### PR TITLE
Feature/component menu

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,7 +3,7 @@
 [include]
 
 [libs]
-
+flow-typed
 [lints]
 
 [options]

--- a/src/client/components/Menu/index.jsx
+++ b/src/client/components/Menu/index.jsx
@@ -1,0 +1,41 @@
+// @flow
+import * as React from "react";
+import styles from "./style.css";
+
+type PropType = {
+  current: string,
+  onButtonClick: (current: string) => void
+};
+
+const menuList: Array<string> = ["入退室処理", "ユーザ登録", "利用者一覧"];
+
+function Menu(props: PropType): React.Node {
+  const { current, onButtonClick } = props;
+  const { menu, list, button, selected } = styles;
+
+  const listItems: Array<React.Node> = menuList.map(
+    (item: string): React.Node => {
+      const className: string =
+        item === current ? `${button} ${selected}` : button;
+      return (
+        <li key={item}>
+          <button
+            className={className}
+            onClick={() => {
+              onButtonClick(item);
+            }}
+          >
+            {item}
+          </button>
+        </li>
+      );
+    }
+  );
+
+  return (
+    <nav className={menu}>
+      <ul className={list}>{listItems}</ul>
+    </nav>
+  );
+}
+export default Menu;

--- a/src/client/components/Menu/style.css
+++ b/src/client/components/Menu/style.css
@@ -1,0 +1,40 @@
+@charset "utf-8";
+.menu {
+  position: absolute;
+  width: 170px;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-color: whitesmoke;
+  box-shadow: 1px 0px 4px 0px silver;
+  z-index: 10;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.button {
+  width: 100%;
+  height: 85px;
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
+  color: gray;
+  background: transparent;
+  border: none;
+  border-bottom: 1px dashed silver;
+  box-sizing: border-box;
+  transition: font-size 200ms;
+  outline: none;
+}
+
+.button.selected {
+  background-color: silver;
+  border: none;
+  color: white;
+  font-size: 24px;
+  font-weight: bold;
+}

--- a/src/client/components/storybook/index.jsx
+++ b/src/client/components/storybook/index.jsx
@@ -1,6 +1,25 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import App from "@components/App";
+import { action } from "@storybook/addon-actions";
+// components
+import Menu from "@components/Menu";
 
-// TODO: テスト実装のため、component作成時にこの例は削除する
-storiesOf("App", module).add("App.jsx", () => <App />);
+storiesOf("Menu", module)
+  .add("[ 入退室処理 ]選択時", () => (
+    <Menu
+      current="入退室処理"
+      onButtonClick={action("引数に文字列が渡される")}
+    />
+  ))
+  .add("[ ユーザ登録 ]選択時", () => (
+    <Menu
+      current="ユーザ登録"
+      onButtonClick={action("引数に文字列が渡される")}
+    />
+  ))
+  .add("[ 利用者一覧 ]選択時", () => (
+    <Menu
+      current="利用者一覧"
+      onButtonClick={action("引数に文字列が渡される")}
+    />
+  ));

--- a/test/client/components/Menu.spec.jsx
+++ b/test/client/components/Menu.spec.jsx
@@ -1,0 +1,104 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Menu from "@components/Menu";
+
+describe("Menu.jsxのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンダリング", () => {
+      const tree = renderer
+        .create(<Menu current="入退室処理" onButtonClick={() => {}} />)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    it("button要素を3つもつ", () => {
+      const menu = shallow(<Menu />);
+      const buttons = menu.find("button");
+      expect(buttons).toHaveLength(3);
+      expect(buttons.at(0).text()).toBe("入退室処理");
+      expect(buttons.at(1).text()).toBe("ユーザ登録");
+      expect(buttons.at(2).text()).toBe("利用者一覧");
+    });
+
+    describe("currentに「入退室処理」を指定する", () => {
+      it("「入退室処理」ボタンにcssクラス: selectedをもつ", () => {
+        const menu = shallow(<Menu current="入退室処理" />);
+        const buttons = menu.find("button");
+        expect(buttons.at(0).hasClass("selected")).toBeTruthy();
+        expect(buttons.at(1).hasClass("selected")).toBeFalsy();
+        expect(buttons.at(2).hasClass("selected")).toBeFalsy();
+      });
+    });
+
+    describe("currentに「ユーザ登録」を指定する", () => {
+      it("「ユーザ登録」ボタンにcssクラス: selectedをもつ", () => {});
+      const menu = shallow(<Menu current="ユーザ登録" />);
+      const buttons = menu.find("button");
+      expect(buttons.at(0).hasClass("selected")).toBeFalsy();
+      expect(buttons.at(1).hasClass("selected")).toBeTruthy();
+      expect(buttons.at(2).hasClass("selected")).toBeFalsy();
+    });
+
+    describe("currentに「利用者一覧」を指定する", () => {
+      it("「利用者一覧」ボタンにcssクラス: selectedをもつ", () => {
+        const menu = shallow(<Menu current="利用者一覧" />);
+        const buttons = menu.find("button");
+        expect(buttons.at(0).hasClass("selected")).toBeFalsy();
+        expect(buttons.at(1).hasClass("selected")).toBeFalsy();
+        expect(buttons.at(2).hasClass("selected")).toBeTruthy();
+      });
+    });
+
+    describe("currentに何も指定しない", () => {
+      it("どのボタンもcssクラス: selectedを持たない", () => {
+        const menu = shallow(<Menu current="" />);
+        const buttons = menu.find("button");
+        expect(buttons.at(0).hasClass("selected")).toBeFalsy();
+        expect(buttons.at(1).hasClass("selected")).toBeFalsy();
+        expect(buttons.at(2).hasClass("selected")).toBeFalsy();
+      });
+    });
+
+    describe("buttonをクリック", () => {
+      const onButtonClick = jest.fn();
+      let menu;
+      beforeEach(() => {
+        menu = shallow(<Menu onButtonClick={onButtonClick} />);
+        onButtonClick.mockReset();
+      });
+
+      describe("「入退室処理」をクリックする", () => {
+        it("引数に'入退室処理'が渡される", () => {
+          menu
+            .find("button")
+            .at(0)
+            .simulate("click");
+          expect(onButtonClick.mock.calls[0][0]).toBe("入退室処理");
+        });
+      });
+
+      describe("「ユーザ登録」をクリックする", () => {
+        it("引数に'ユーザ登録'が渡される", () => {
+          menu
+            .find("button")
+            .at(1)
+            .simulate("click");
+          expect(onButtonClick.mock.calls[0][0]).toBe("ユーザ登録");
+        });
+      });
+
+      describe("「利用者一覧」をクリックする", () => {
+        it("引数に'利用者一覧'が渡される", () => {
+          menu
+            .find("button")
+            .at(2)
+            .simulate("click");
+          expect(onButtonClick.mock.calls[0][0]).toBe("利用者一覧");
+        });
+      });
+    });
+  });
+});

--- a/test/client/components/__snapshots__/Menu.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Menu.spec.jsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Menu.jsxのテスト スナップショット 正しいレンダリング 1`] = `
+<nav
+  className="menu"
+>
+  <ul
+    className="list"
+  >
+    <li>
+      <button
+        className="button selected"
+        onClick={[Function]}
+      >
+        入退室処理
+      </button>
+    </li>
+    <li>
+      <button
+        className="button"
+        onClick={[Function]}
+      >
+        ユーザ登録
+      </button>
+    </li>
+    <li>
+      <button
+        className="button"
+        onClick={[Function]}
+      >
+        利用者一覧
+      </button>
+    </li>
+  </ul>
+</nav>
+`;


### PR DESCRIPTION
## 関連issue
メニューコンポーネント作成 #104

## 概要
- Menuコンポーネント作成
- storybookにMenuコンポーネントを追加
- 単体test実施
- .flowconfigの変更

## 補足点
- 開発PCを変更したためか、flowでエラーが発生。flowconfigを修正して回避。ローカルで使用するように変更してきた影響かは不明。
- オブジェクトの分割代入
  - `props.xxx`で関数を実装すると、eslintが`react/no-unused-prop-types`でエラーを出します。回避するため、分割代入してます。`ex, const { hoge } = props;`
  - 分割代入は、コードの可読性があがりメリットがあると思うので、今後も分割代入を採用していこうと思います。