### PR TITLE
[change] storybookをリファクタリング。コンポーネント毎にstorybookのファイルを作成するように変更

### DIFF
--- a/src/client/components/Participant/ListBody.jsx
+++ b/src/client/components/Participant/ListBody.jsx
@@ -1,0 +1,45 @@
+// @flow
+import * as React from "react";
+import Purpose from "./Purpose";
+import Status from "./Status";
+import styles from "./style.css";
+
+export type DataType = {
+  name: string,
+  purpose: string,
+  isEntry: boolean
+};
+
+type ListBodyType = {
+  listData: Array<DataType>
+};
+
+function ListBody(props: ListBodyType): React.Node {
+  const { body, columnName, border, buttom } = styles;
+  const { listData } = props;
+  const { length } = listData;
+
+  const listItems = listData.map(
+    (data: DataType, index: number): React.Node => {
+      const { name, purpose, isEntry } = data;
+      const listButtom: string =
+        index === length - 1 && index > 5 ? "" : buttom;
+      const key = `list-${index}`;
+
+      return (
+        <li key={key} className={listButtom}>
+          <div className={`${columnName} ${border}`}>{name}</div>
+          <Purpose purpose={purpose} />
+          <Status isEntry={isEntry} />
+        </li>
+      );
+    }
+  );
+
+  return (
+    <div className={body}>
+      <ul>{listItems}</ul>
+    </div>
+  );
+}
+export default ListBody;

--- a/src/client/components/Participant/ListHeader.jsx
+++ b/src/client/components/Participant/ListHeader.jsx
@@ -1,0 +1,15 @@
+// @flow
+import * as React from "react";
+import styles from "./style.css";
+
+function ListHeader(): React.Node {
+  const { header, columnName, columnPurpose, columnStatus, border } = styles;
+  return (
+    <div className={header}>
+      <div className={`${columnName} ${border}`}>名前</div>
+      <div className={`${columnPurpose} ${border}`}>目的</div>
+      <div className={columnStatus}>入退室</div>
+    </div>
+  );
+}
+export default ListHeader;

--- a/src/client/components/Participant/Purpose.jsx
+++ b/src/client/components/Participant/Purpose.jsx
@@ -1,0 +1,37 @@
+// @flow
+import * as React from "react";
+import styles from "./style.css";
+
+type PurposeType = {
+  purpose: string
+};
+
+function Purpose(props: PurposeType): React.Node {
+  const { purpose } = props;
+  const { columnPurpose, border, work, study, meetUp, circle } = styles;
+
+  let background: string = "";
+  let value: string = "";
+
+  if (purpose === "study") {
+    background = study;
+    value = "自習";
+  }
+  if (purpose === "meetUp") {
+    background = meetUp;
+    value = "勉強会";
+  }
+  if (purpose === "work") {
+    background = work;
+    value = "仕事";
+  }
+  if (purpose === "circle") {
+    background = circle;
+    value = "サークル";
+  }
+
+  return (
+    <div className={`${columnPurpose} ${background} ${border}`}>{value}</div>
+  );
+}
+export default Purpose;

--- a/src/client/components/Participant/Status.jsx
+++ b/src/client/components/Participant/Status.jsx
@@ -1,0 +1,20 @@
+// @flow
+import * as React from "react";
+import styles from "./style.css";
+
+type StatusType = {
+  isEntry: boolean
+};
+
+function Status(props: StatusType): React.Node {
+  const { isEntry } = props;
+  const { columnStatus, entry, exit } = styles;
+
+  const className = isEntry
+    ? `${columnStatus} ${entry}`
+    : `${columnStatus} ${exit}`;
+  const value = isEntry ? "入" : "退";
+
+  return <div className={className}>{value}</div>;
+}
+export default Status;

--- a/src/client/components/Participant/index.jsx
+++ b/src/client/components/Participant/index.jsx
@@ -1,0 +1,27 @@
+// @flow
+import * as React from "react";
+import ListHeader from "./ListHeader";
+import type { DataType } from "./ListBody";
+import ListBody from "./ListBody";
+import styles from "./style.css";
+
+// 参加者
+type ParticipantType = {
+  data: Array<DataType>
+};
+
+function Participant(props: ParticipantType): React.Node {
+  const { flame, list } = styles;
+  const { data } = props;
+
+  return (
+    <div className={flame}>
+      <div className={list}>
+        <ListHeader />
+        <ListBody listData={data} />
+      </div>
+    </div>
+  );
+}
+
+export default Participant;

--- a/src/client/components/Participant/style.css
+++ b/src/client/components/Participant/style.css
@@ -1,0 +1,102 @@
+@charset "utf-8";
+.flame {
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+  background: white;
+  border-radius: 8px;
+  box-sizing: border-box;
+}
+
+.list {
+  height: 100%;
+  font-size: 24px;
+}
+
+.list .header {
+  display: flex;
+  height: 60px;
+  font-weight: bold;
+  border: 2px solid lightgray;
+  box-sizing: border-box;
+}
+
+.list .header > div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.columnName {
+  flex-grow: 1;
+}
+
+.columnPurpose {
+  width: 130px;
+}
+
+.columnStatus {
+  width: 90px;
+}
+
+.border {
+  border-right: 2px solid lightgray;
+  box-sizing: border-box;
+}
+
+.list .body {
+  height: calc(100% - 60px);
+  border: 2px solid lightgray;
+  border-top: transparent;
+  box-sizing: border-box;
+  overflow: scroll;
+}
+
+.list .body ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.list .body li {
+  display: flex;
+  height: 52px;
+}
+
+.list .body li.buttom {
+  border-bottom: 2px solid lightgray;
+}
+
+.list .body li > div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* 仕事 */
+.work {
+  background-color: #bbfeff;
+}
+
+/* 自習 */
+.study {
+  background-color: #bcf3cb;
+}
+
+/* 勉強会 */
+.meetUp {
+  background-color: #f8f189;
+}
+
+/* サークル */
+.circle {
+  background-color: #f4d8f5;
+}
+
+.entry {
+  background-color: #ffd400;
+}
+
+.exit {
+  background-color: #ebebeb;
+}

--- a/src/client/components/storybook/.eslintrc.json
+++ b/src/client/components/storybook/.eslintrc.json
@@ -1,6 +1,9 @@
 {
   "rules": {
     "import/no-extraneous-dependencies": 0,
-    "flowtype/require-return-type": 0
+    "flowtype/require-return-type": 0,
+    "global-require": 0,
+    "flowtype/require-parameter-type": 0,
+    "react/prop-types": 0
   }
 }

--- a/src/client/components/storybook/DummyContainer/index.jsx
+++ b/src/client/components/storybook/DummyContainer/index.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import styles from "./style.css";
+
+// ダミーコンテナ
+function DummyContainer(props) {
+  const { children } = props;
+  return <div className={styles.container}>{children}</div>;
+}
+export default DummyContainer;

--- a/src/client/components/storybook/DummyContainer/style.css
+++ b/src/client/components/storybook/DummyContainer/style.css
@@ -1,0 +1,7 @@
+@charset "utf-8";
+.container {
+  position: relative;
+  width: 800px;
+  height: 480px;
+  border: 1px solid black;
+}

--- a/src/client/components/storybook/config.js
+++ b/src/client/components/storybook/config.js
@@ -1,8 +1,8 @@
 import { configure } from "@storybook/react";
 
 function loadStories() {
-  // eslint-disable-next-line global-require
-  require("./index");
+  require("./stories/menu");
+  require("./stories/mainFlame");
 }
 
 configure(loadStories, module);

--- a/src/client/components/storybook/config.js
+++ b/src/client/components/storybook/config.js
@@ -3,6 +3,7 @@ import { configure } from "@storybook/react";
 function loadStories() {
   require("./stories/menu");
   require("./stories/mainFlame");
+  require("./stories/participant");
 }
 
 configure(loadStories, module);

--- a/src/client/components/storybook/stories/mainFlame.jsx
+++ b/src/client/components/storybook/stories/mainFlame.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import MainFlame from "@components/MainFlame";
+import DummyContainer from "../DummyContainer";
+import styles from "./style.css";
+
+// ダミーコンテンツ
+function DummyContent() {
+  return <div className={styles.contentArea}>コンテンツ領域</div>;
+}
+
+// #region MainFlame
+storiesOf("MainFlame", module)
+  .add("デフォルト", () => (
+    <DummyContainer>
+      <MainFlame type="default">
+        <DummyContent />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("仕事", () => (
+    <DummyContainer>
+      <MainFlame type="work">
+        <DummyContent />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("自習", () => (
+    <DummyContainer>
+      <MainFlame type="study">
+        <DummyContent />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("勉強会", () => (
+    <DummyContainer>
+      <MainFlame type="meetUp">
+        <DummyContent />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("サークル", () => (
+    <DummyContainer>
+      <MainFlame type="circle">
+        <DummyContent />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("退出", () => (
+    <DummyContainer>
+      <MainFlame type="exit">
+        <DummyContent />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("エラー", () => (
+    <DummyContainer>
+      <MainFlame type="error">
+        <DummyContent />
+      </MainFlame>
+    </DummyContainer>
+  ));

--- a/src/client/components/storybook/stories/menu.jsx
+++ b/src/client/components/storybook/stories/menu.jsx
@@ -1,20 +1,8 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-// components
 import Menu from "@components/Menu";
-import MainFlame from "@components/MainFlame";
 
-import styles from "./style.css";
-
-// storybook用のコンテナーフレーム
-// eslint-disable-next-line flowtype/require-parameter-type
-function ContainerFlame(props) {
-  // eslint-disable-next-line react/prop-types
-  return <div className={styles.container}>{props.children}</div>;
-}
-
-// #region Menu
 storiesOf("Menu", module)
   .add("[ 入退室処理 ]選択時", () => (
     <Menu
@@ -34,14 +22,3 @@ storiesOf("Menu", module)
       onButtonClick={action("引数に文字列が渡される")}
     />
   ));
-// #endregion Menu
-
-// #region MainFlame
-storiesOf("MainFlame", module).add("コンテンツのメインフレーム", () => (
-  <ContainerFlame>
-    <MainFlame>
-      <div className={styles.contentArea}>コンテンツ領域</div>
-    </MainFlame>
-  </ContainerFlame>
-));
-// #endregion MainFlame

--- a/src/client/components/storybook/stories/participant.jsx
+++ b/src/client/components/storybook/stories/participant.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import MainFlame from "@components/MainFlame";
+import Participant from "@components/Participant";
+import DummyContainer from "../DummyContainer";
+
+// demo data
+const data = [
+  {
+    name: "名前1",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "名前2",
+    purpose: "meetUp",
+    isEntry: true
+  },
+  {
+    name: "名前3",
+    purpose: "work",
+    isEntry: true
+  },
+  {
+    name: "名前4",
+    purpose: "circle",
+    isEntry: true
+  },
+  {
+    name: "名前5",
+    purpose: "circle",
+    isEntry: true
+  },
+  {
+    name: "名前6",
+    purpose: "circle",
+    isEntry: true
+  },
+  {
+    name: "名前7",
+    purpose: "circle",
+    isEntry: true
+  },
+  {
+    name: "名前8",
+    purpose: "meetUp",
+    isEntry: false
+  },
+  {
+    name: "名前9",
+    purpose: "work",
+    isEntry: false
+  },
+  {
+    name: "名前10",
+    purpose: "work",
+    isEntry: false
+  },
+  {
+    name: "名前11",
+    purpose: "meetUp",
+    isEntry: false
+  }
+];
+
+storiesOf("Participant", module).add("参加者一覧", () => (
+  <DummyContainer>
+    <MainFlame type="standard">
+      <Participant data={data} />
+    </MainFlame>
+  </DummyContainer>
+));

--- a/src/client/components/storybook/stories/style.css
+++ b/src/client/components/storybook/stories/style.css
@@ -1,11 +1,4 @@
 @charset "utf-8";
-.container {
-  position: relative;
-  width: 800px;
-  height: 480px;
-  border: 1px solid black;
-}
-
 .contentArea {
   display: flex;
   width: 100%;

--- a/src/client/components/storybook/webpack.config.js
+++ b/src/client/components/storybook/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 
 module.exports = {
   resolve: {
+    extensions: [".jsx", ".js"],
     alias: {
       "@components": path.resolve(__dirname, "../")
     }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "flowtype/require-parameter-type": 0
+  }
+}

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "flowtype/require-parameter-type": 0
+    "flowtype/require-parameter-type": 0,
+    "flowtype/require-return-type": 0
   }
 }

--- a/test/client/components/Participant.ListBody.spec.jsx
+++ b/test/client/components/Participant.ListBody.spec.jsx
@@ -20,6 +20,14 @@ describe("Participant.ListBody.jsxのテスト", () => {
     const listBody = shallow(<ListBody listData={shortParticipantData} />);
     const listItems = listBody.find("li");
 
+    it("各<li>のname項目には、渡されたdataのnameの値が表示されている", () => {
+      listItems.forEach((node, index) => {
+        expect(node.find(".columnName").text()).toBe(
+          shortParticipantData[index].name
+        );
+      });
+    });
+
     it("Purposeコンポーネントのpurposeに、値を渡している", () => {
       listItems.forEach((node, index) =>
         expect(

--- a/test/client/components/Participant.ListBody.spec.jsx
+++ b/test/client/components/Participant.ListBody.spec.jsx
@@ -2,11 +2,13 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
 import ListBody from "@components/Participant/ListBody";
+import Purpose from "@components/Participant/Purpose";
+import Status from "@components/Participant/Status";
 import { shortParticipantData, longParticipantData } from "./testData";
 
 describe("Participant.ListBody.jsxのテスト", () => {
   describe("スナップショット", () => {
-    it("正しいレンタリング", () => {
+    it("正しいレンダリング", () => {
       const tree = renderer
         .create(<ListBody listData={shortParticipantData} />)
         .toJSON();
@@ -15,49 +17,42 @@ describe("Participant.ListBody.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    it("Purposeコンポーネントのpurposeに、値を渡している", () => {
-      const purposeComponents = shallow(
-        <ListBody listData={shortParticipantData} />
-      ).find("Purpose");
+    const listBody = shallow(<ListBody listData={shortParticipantData} />);
+    const listItems = listBody.find("li");
 
-      shortParticipantData.forEach((data, index) => {
-        expect(purposeComponents.at(index).prop("purpose")).toBe(data.purpose);
-      });
+    it("Purposeコンポーネントのpurposeに、値を渡している", () => {
+      listItems.forEach((node, index) =>
+        expect(
+          node.contains(
+            <Purpose purpose={shortParticipantData[index].purpose} />
+          )
+        )
+      );
     });
 
     it("StatusコンポーネントのisEntryに、値を渡している", () => {
-      const statusComponents = shallow(
-        <ListBody listData={shortParticipantData} />
-      ).find("Status");
-
-      statusComponents.forEach((node, index) => {
-        if (shortParticipantData[index].isEntry) {
-          expect(node.prop("isEntry")).toBeTruthy();
-        } else {
-          expect(node.prop("isEntry")).toBeFalsy();
-        }
-      });
+      listItems.forEach((node, index) =>
+        expect(
+          node.contains(
+            <Status isEntry={shortParticipantData[index].isEntry} />
+          )
+        )
+      );
     });
 
-    describe("listDataにshortParticipantDataを指定した時", () => {
-      it("listItemの要素全てにcssクラス: buttomをもつ", () => {
-        const listItems = shallow(
-          <ListBody listData={shortParticipantData} />
-        ).find("li");
-
-        listItems.forEach(node => {
-          expect(node.hasClass("buttom")).toBeTruthy();
-        });
+    it("listItemの要素全てにcssクラス: buttomをもつ", () => {
+      listItems.forEach(node => {
+        expect(node.hasClass("buttom")).toBeTruthy();
       });
     });
 
     describe("listDataにlongParticipantDataを指定した時", () => {
       it("最後の要素はcssクラス: buttomをもたない", () => {
-        const listItems = shallow(
+        const longListItems = shallow(
           <ListBody listData={longParticipantData} />
         ).find("li");
-        const { length } = listItems;
-        listItems.forEach((node, index) => {
+        const { length } = longListItems;
+        longListItems.forEach((node, index) => {
           if (index === length - 1) {
             expect(node.hasClass("buttom")).toBeFalsy();
           } else {

--- a/test/client/components/Participant.ListBody.spec.jsx
+++ b/test/client/components/Participant.ListBody.spec.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import ListBody from "@components/Participant/ListBody";
+import { shortParticipantData, longParticipantData } from "./testData";
+
+describe("Participant.ListBody.jsxのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンタリング", () => {
+      const tree = renderer
+        .create(<ListBody listData={shortParticipantData} />)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    it("Purposeコンポーネントのpurposeに、値を渡している", () => {
+      const purposeComponents = shallow(
+        <ListBody listData={shortParticipantData} />
+      ).find("Purpose");
+
+      shortParticipantData.forEach((data, index) => {
+        expect(purposeComponents.at(index).prop("purpose")).toBe(data.purpose);
+      });
+    });
+
+    it("StatusコンポーネントのisEntryに、値を渡している", () => {
+      const statusComponents = shallow(
+        <ListBody listData={shortParticipantData} />
+      ).find("Status");
+
+      statusComponents.forEach((node, index) => {
+        if (shortParticipantData[index].isEntry) {
+          expect(node.prop("isEntry")).toBeTruthy();
+        } else {
+          expect(node.prop("isEntry")).toBeFalsy();
+        }
+      });
+    });
+
+    describe("listDataにshortParticipantDataを指定した時", () => {
+      it("listItemの要素全てにcssクラス: buttomをもつ", () => {
+        const listItems = shallow(
+          <ListBody listData={shortParticipantData} />
+        ).find("li");
+
+        listItems.forEach(node => {
+          expect(node.hasClass("buttom")).toBeTruthy();
+        });
+      });
+    });
+
+    describe("listDataにlongParticipantDataを指定した時", () => {
+      it("最後の要素はcssクラス: buttomをもたない", () => {
+        const listItems = shallow(
+          <ListBody listData={longParticipantData} />
+        ).find("li");
+        const { length } = listItems;
+        listItems.forEach((node, index) => {
+          if (index === length - 1) {
+            expect(node.hasClass("buttom")).toBeFalsy();
+          } else {
+            expect(node.hasClass("buttom")).toBeTruthy();
+          }
+        });
+      });
+    });
+  });
+});

--- a/test/client/components/Participant.ListHeader.spec.jsx
+++ b/test/client/components/Participant.ListHeader.spec.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import ListHeader from "@components/Participant/ListHeader";
+
+describe("Participant.ListHeader.jsxのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンダリング", () => {
+      const tree = renderer.create(<ListHeader />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    const header = shallow(<ListHeader />);
+    const children = header.find(".header > div");
+    it("cssクラス: headerをもつ", () => {
+      expect(header.hasClass("header")).toBeTruthy();
+    });
+
+    it("cssクラス: headerをもつdiv要素は、子要素にdiv要素を3つもつ", () => {
+      expect(children).toHaveLength(3);
+    });
+
+    it("cssクラス: headerをもつdivの1つめの子要素は、項目名が[名前]", () => {
+      const child = children.at(0);
+      expect(child.hasClass("columnName")).toBeTruthy();
+      expect(child.hasClass("border")).toBeTruthy();
+      expect(child.text("名前")).toBeTruthy();
+    });
+
+    it("cssクラス: headerをもつdivの2つめの子要素は、項目名が[目的]", () => {
+      const child = children.at(1);
+      expect(child.hasClass("columnPurpose")).toBeTruthy();
+      expect(child.hasClass("border")).toBeTruthy();
+      expect(child.text("目的")).toBeTruthy();
+    });
+
+    it("cssクラス: headerをもつdivの3つめの子要素は、項目名が[入退室]", () => {
+      const child = children.at(2);
+      expect(child.hasClass("columnStatus")).toBeTruthy();
+      expect(child.text("入退室")).toBeTruthy();
+    });
+  });
+});

--- a/test/client/components/Participant.Purpose.spec.jsx
+++ b/test/client/components/Participant.Purpose.spec.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Purpose from "@components/Participant/Purpose";
+
+describe("Participant.Purpose.jsxのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンダリング", () => {
+      const tree = renderer.create(<Purpose purpose="study" />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    it("cssクラス: columnPurpose, borderをもつ", () => {
+      const purpose = shallow(<Purpose />);
+      expect(purpose.hasClass("columnPurpose")).toBeTruthy();
+      expect(purpose.hasClass("border")).toBeTruthy();
+    });
+
+    describe("purposeにstudyを指定した時", () => {
+      it("共通のcssクラスの他にstudyをもち、自習と表示される", () => {
+        const purpose = shallow(<Purpose purpose="study" />);
+        expect(purpose.hasClass("columnPurpose")).toBeTruthy();
+        expect(purpose.hasClass("border")).toBeTruthy();
+        expect(purpose.hasClass("study")).toBeTruthy();
+        expect(purpose.text("自習")).toBeTruthy();
+      });
+    });
+
+    describe("purposeにmeetUpを指定した時", () => {
+      it("共通のcssクラスの他にmeetUpをもち、勉強会と表示される", () => {
+        const purpose = shallow(<Purpose purpose="meetUp" />);
+        expect(purpose.hasClass("columnPurpose")).toBeTruthy();
+        expect(purpose.hasClass("border")).toBeTruthy();
+        expect(purpose.hasClass("meetUp")).toBeTruthy();
+        expect(purpose.text("勉強会")).toBeTruthy();
+      });
+    });
+
+    describe("purposeにworkを指定した時", () => {
+      it("共通のcssクラスの他にworkをもち、仕事と表示される", () => {
+        const purpose = shallow(<Purpose purpose="work" />);
+        expect(purpose.hasClass("columnPurpose")).toBeTruthy();
+        expect(purpose.hasClass("border")).toBeTruthy();
+        expect(purpose.hasClass("work")).toBeTruthy();
+        expect(purpose.text("仕事")).toBeTruthy();
+      });
+    });
+
+    describe("purposeにcircleを指定した時", () => {
+      it("共通のcssクラスの他にcircleをもち、サークルと表示される", () => {
+        const purpose = shallow(<Purpose purpose="circle" />);
+        expect(purpose.hasClass("columnPurpose")).toBeTruthy();
+        expect(purpose.hasClass("border")).toBeTruthy();
+        expect(purpose.hasClass("circle")).toBeTruthy();
+        expect(purpose.text("サークル")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/test/client/components/Participant.Status.spec.jsx
+++ b/test/client/components/Participant.Status.spec.jsx
@@ -3,7 +3,7 @@ import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
 import Status from "@components/Participant/Status";
 
-describe("Participant.Status.jsxjのテスト", () => {
+describe("Participant.Status.jsxのテスト", () => {
   describe("スナップショット", () => {
     it("正しいレンタリング", () => {
       const tree = renderer.create(<Status isEntry />).toJSON();

--- a/test/client/components/Participant.Status.spec.jsx
+++ b/test/client/components/Participant.Status.spec.jsx
@@ -5,7 +5,7 @@ import Status from "@components/Participant/Status";
 
 describe("Participant.Status.jsxのテスト", () => {
   describe("スナップショット", () => {
-    it("正しいレンタリング", () => {
+    it("正しいレンダリング", () => {
       const tree = renderer.create(<Status isEntry />).toJSON();
       expect(tree).toMatchSnapshot();
     });

--- a/test/client/components/Participant.Status.spec.jsx
+++ b/test/client/components/Participant.Status.spec.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Status from "@components/Participant/Status";
+
+describe("Participant.Status.jsxjのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンタリング", () => {
+      const tree = renderer.create(<Status isEntry />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    describe("属性にisEntryを指定した時", () => {
+      it("共通のcssクラスの他にentryをもち、入と表示される", () => {
+        const status = shallow(<Status isEntry />);
+        expect(status.hasClass("columnStatus")).toBeTruthy();
+        expect(status.hasClass("entry")).toBeTruthy();
+        expect(status.text("入")).toBeTruthy();
+      });
+    });
+
+    describe("属性にisEntryを指定しない時", () => {
+      it("共通のcssクラスの他にexitをもち、退と表示される", () => {
+        const status = shallow(<Status />);
+        expect(status.hasClass("columnStatus")).toBeTruthy();
+        expect(status.hasClass("exit")).toBeTruthy();
+        expect(status.text("退")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/test/client/components/Participant.spec.jsx
+++ b/test/client/components/Participant.spec.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Participant from "@components/Participant";
+import ListHeader from "@components/Participant/ListHeader";
+import ListBody from "@components/Participant/ListBody";
+import { shortParticipantData } from "./testData";
+
+describe("Participantのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンダリング", () => {
+      const tree = renderer
+        .create(<Participant data={shortParticipantData} />)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    const participant = shallow(<Participant data={shortParticipantData} />);
+    it("cssクラス: flameをもつ", () => {
+      expect(participant.hasClass("flame")).toBeTruthy();
+    });
+
+    it("childrenは、cssクラス: listをもつ", () => {
+      expect(participant.children().hasClass("list")).toBeTruthy();
+    });
+
+    it("ListHeaderコンポーネントを使用している", () => {
+      expect(participant.contains(<ListHeader />)).toBeTruthy();
+    });
+
+    it("ListBodyコンポーネントのlistDataに、shortParticipantDataを渡している", () => {
+      expect(
+        participant.contains(<ListBody listData={shortParticipantData} />)
+      ).toBeTruthy();
+    });
+  });
+});

--- a/test/client/components/__snapshots__/Participant.ListBody.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.ListBody.spec.jsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Participant.ListBody.jsxのテスト スナップショット 正しいレンタリング 1`] = `
+<div
+  className="body"
+>
+  <ul>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name1
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus entry"
+      >
+        入
+      </div>
+    </li>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name2
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus entry"
+      >
+        入
+      </div>
+    </li>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name3
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus entry"
+      >
+        入
+      </div>
+    </li>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name4
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus entry"
+      >
+        入
+      </div>
+    </li>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name5
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus exit"
+      >
+        退
+      </div>
+    </li>
+  </ul>
+</div>
+`;

--- a/test/client/components/__snapshots__/Participant.ListBody.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.ListBody.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Participant.ListBody.jsxのテスト スナップショット 正しいレンタリング 1`] = `
+exports[`Participant.ListBody.jsxのテスト スナップショット 正しいレンダリング 1`] = `
 <div
   className="body"
 >

--- a/test/client/components/__snapshots__/Participant.ListHeader.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.ListHeader.spec.jsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Participant.ListHeader.jsxのテスト スナップショット 正しいレンダリング 1`] = `
+<div
+  className="header"
+>
+  <div
+    className="columnName border"
+  >
+    名前
+  </div>
+  <div
+    className="columnPurpose border"
+  >
+    目的
+  </div>
+  <div
+    className="columnStatus"
+  >
+    入退室
+  </div>
+</div>
+`;

--- a/test/client/components/__snapshots__/Participant.Purpose.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.Purpose.spec.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Participant.Purpose.jsxのテスト スナップショット 正しいレンダリング 1`] = `
+<div
+  className="columnPurpose study border"
+>
+  自習
+</div>
+`;

--- a/test/client/components/__snapshots__/Participant.Status.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.Status.spec.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Participant.Status.jsxjのテスト スナップショット 正しいレンタリング 1`] = `
+<div
+  className="columnStatus entry"
+>
+  入
+</div>
+`;

--- a/test/client/components/__snapshots__/Participant.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.spec.jsx.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Participantのテスト スナップショット 正しいレンダリング 1`] = `
+<div
+  className="flame"
+>
+  <div
+    className="list"
+  >
+    <div
+      className="header"
+    >
+      <div
+        className="columnName border"
+      >
+        名前
+      </div>
+      <div
+        className="columnPurpose border"
+      >
+        目的
+      </div>
+      <div
+        className="columnStatus"
+      >
+        入退室
+      </div>
+    </div>
+    <div
+      className="body"
+    >
+      <ul>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name1
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus entry"
+          >
+            入
+          </div>
+        </li>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name2
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus entry"
+          >
+            入
+          </div>
+        </li>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name3
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus entry"
+          >
+            入
+          </div>
+        </li>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name4
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus entry"
+          >
+            入
+          </div>
+        </li>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name5
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus exit"
+          >
+            退
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/test/client/components/testData.js
+++ b/test/client/components/testData.js
@@ -1,0 +1,70 @@
+export const shortParticipantData = [
+  {
+    name: "name1",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name2",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name3",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name4",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name5",
+    purpose: "study",
+    isEntry: false
+  }
+];
+
+export const longParticipantData = [
+  {
+    name: "name1",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name2",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name3",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name4",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name5",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name6",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name7",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name8",
+    purpose: "study",
+    isEntry: true
+  }
+];


### PR DESCRIPTION
## 該当issue
[リファクタリング] storybook #139

## 概要
- storybookファイルをコンポーネント毎に切り出した
  - ファイル名の命名規則として、`stories/{コンポーネント名(キャメルケース)}`としています
- 親のheight, widthを継承するコンポーネントがあるので、storybook用の`DummyContainer`コンポーネントを作成
- eslintの一部ルールを無効化
  - type使用を強制するルール
  - コードの途中で`require`を禁止するルール