### PR TITLE
[add] Participantコンポーネントのリストボディを作成

### DIFF
--- a/src/client/components/Participant/ListBody.jsx
+++ b/src/client/components/Participant/ListBody.jsx
@@ -1,0 +1,45 @@
+// @flow
+import * as React from "react";
+import Purpose from "./Purpose";
+import Status from "./Status";
+import styles from "./style.css";
+
+export type DataType = {
+  name: string,
+  purpose: string,
+  isEntry: boolean
+};
+
+type ListBodyType = {
+  listData: Array<DataType>
+};
+
+function ListBody(props: ListBodyType): React.Node {
+  const { body, columnName, border, buttom } = styles;
+  const { listData } = props;
+  const { length } = listData;
+
+  const listItems = listData.map(
+    (data: DataType, index: number): React.Node => {
+      const { name, purpose, isEntry } = data;
+      const listButtom: string =
+        index === length - 1 && index > 5 ? "" : buttom;
+      const key = `list-${index}`;
+
+      return (
+        <li key={key} className={listButtom}>
+          <div className={`${columnName} ${border}`}>{name}</div>
+          <Purpose purpose={purpose} />
+          <Status isEntry={isEntry} />
+        </li>
+      );
+    }
+  );
+
+  return (
+    <div className={body}>
+      <ul>{listItems}</ul>
+    </div>
+  );
+}
+export default ListBody;

--- a/src/client/components/Participant/index.jsx
+++ b/src/client/components/Participant/index.jsx
@@ -1,0 +1,27 @@
+// @flow
+import * as React from "react";
+import ListHeader from "./ListHeader";
+import type { DataType } from "./ListBody";
+import ListBody from "./ListBody";
+import styles from "./style.css";
+
+// 参加者
+type ParticipantType = {
+  data: Array<DataType>
+};
+
+function Participant(props: ParticipantType): React.Node {
+  const { flame, list } = styles;
+  const { data } = props;
+
+  return (
+    <div className={flame}>
+      <div className={list}>
+        <ListHeader />
+        <ListBody listData={data} />
+      </div>
+    </div>
+  );
+}
+
+export default Participant;

--- a/src/client/components/storybook/config.js
+++ b/src/client/components/storybook/config.js
@@ -3,6 +3,7 @@ import { configure } from "@storybook/react";
 function loadStories() {
   require("./stories/menu");
   require("./stories/mainFlame");
+  require("./stories/participant");
 }
 
 configure(loadStories, module);

--- a/src/client/components/storybook/stories/participant.jsx
+++ b/src/client/components/storybook/stories/participant.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import MainFlame from "@components/MainFlame";
+import Participant from "@components/Participant";
+import DummyContainer from "../DummyContainer";
+
+// demo data
+const data = [
+  {
+    name: "名前1",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "名前2",
+    purpose: "meetUp",
+    isEntry: true
+  },
+  {
+    name: "名前3",
+    purpose: "work",
+    isEntry: true
+  },
+  {
+    name: "名前4",
+    purpose: "circle",
+    isEntry: true
+  },
+  {
+    name: "名前5",
+    purpose: "circle",
+    isEntry: true
+  },
+  {
+    name: "名前6",
+    purpose: "circle",
+    isEntry: true
+  },
+  {
+    name: "名前7",
+    purpose: "circle",
+    isEntry: true
+  },
+  {
+    name: "名前8",
+    purpose: "meetUp",
+    isEntry: false
+  },
+  {
+    name: "名前9",
+    purpose: "work",
+    isEntry: false
+  },
+  {
+    name: "名前10",
+    purpose: "work",
+    isEntry: false
+  },
+  {
+    name: "名前11",
+    purpose: "meetUp",
+    isEntry: false
+  }
+];
+
+storiesOf("Participant", module).add("参加者一覧", () => (
+  <DummyContainer>
+    <MainFlame type="standard">
+      <Participant data={data} />
+    </MainFlame>
+  </DummyContainer>
+));

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "flowtype/require-parameter-type": 0
+  }
+}

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "flowtype/require-parameter-type": 0
+    "flowtype/require-parameter-type": 0,
+    "flowtype/require-return-type": 0
   }
 }

--- a/test/client/components/Participant.ListBody.spec.jsx
+++ b/test/client/components/Participant.ListBody.spec.jsx
@@ -20,6 +20,14 @@ describe("Participant.ListBody.jsxのテスト", () => {
     const listBody = shallow(<ListBody listData={shortParticipantData} />);
     const listItems = listBody.find("li");
 
+    it("各<li>のname項目には、渡されたdataのnameの値が表示されている", () => {
+      listItems.forEach((node, index) => {
+        expect(node.find(".columnName").text()).toBe(
+          shortParticipantData[index].name
+        );
+      });
+    });
+
     it("Purposeコンポーネントのpurposeに、値を渡している", () => {
       listItems.forEach((node, index) =>
         expect(

--- a/test/client/components/Participant.ListBody.spec.jsx
+++ b/test/client/components/Participant.ListBody.spec.jsx
@@ -2,11 +2,13 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
 import ListBody from "@components/Participant/ListBody";
+import Purpose from "@components/Participant/Purpose";
+import Status from "@components/Participant/Status";
 import { shortParticipantData, longParticipantData } from "./testData";
 
 describe("Participant.ListBody.jsxのテスト", () => {
   describe("スナップショット", () => {
-    it("正しいレンタリング", () => {
+    it("正しいレンダリング", () => {
       const tree = renderer
         .create(<ListBody listData={shortParticipantData} />)
         .toJSON();
@@ -15,49 +17,42 @@ describe("Participant.ListBody.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    it("Purposeコンポーネントのpurposeに、値を渡している", () => {
-      const purposeComponents = shallow(
-        <ListBody listData={shortParticipantData} />
-      ).find("Purpose");
+    const listBody = shallow(<ListBody listData={shortParticipantData} />);
+    const listItems = listBody.find("li");
 
-      shortParticipantData.forEach((data, index) => {
-        expect(purposeComponents.at(index).prop("purpose")).toBe(data.purpose);
-      });
+    it("Purposeコンポーネントのpurposeに、値を渡している", () => {
+      listItems.forEach((node, index) =>
+        expect(
+          node.contains(
+            <Purpose purpose={shortParticipantData[index].purpose} />
+          )
+        )
+      );
     });
 
     it("StatusコンポーネントのisEntryに、値を渡している", () => {
-      const statusComponents = shallow(
-        <ListBody listData={shortParticipantData} />
-      ).find("Status");
-
-      statusComponents.forEach((node, index) => {
-        if (shortParticipantData[index].isEntry) {
-          expect(node.prop("isEntry")).toBeTruthy();
-        } else {
-          expect(node.prop("isEntry")).toBeFalsy();
-        }
-      });
+      listItems.forEach((node, index) =>
+        expect(
+          node.contains(
+            <Status isEntry={shortParticipantData[index].isEntry} />
+          )
+        )
+      );
     });
 
-    describe("listDataにshortParticipantDataを指定した時", () => {
-      it("listItemの要素全てにcssクラス: buttomをもつ", () => {
-        const listItems = shallow(
-          <ListBody listData={shortParticipantData} />
-        ).find("li");
-
-        listItems.forEach(node => {
-          expect(node.hasClass("buttom")).toBeTruthy();
-        });
+    it("listItemの要素全てにcssクラス: buttomをもつ", () => {
+      listItems.forEach(node => {
+        expect(node.hasClass("buttom")).toBeTruthy();
       });
     });
 
     describe("listDataにlongParticipantDataを指定した時", () => {
       it("最後の要素はcssクラス: buttomをもたない", () => {
-        const listItems = shallow(
+        const longListItems = shallow(
           <ListBody listData={longParticipantData} />
         ).find("li");
-        const { length } = listItems;
-        listItems.forEach((node, index) => {
+        const { length } = longListItems;
+        longListItems.forEach((node, index) => {
           if (index === length - 1) {
             expect(node.hasClass("buttom")).toBeFalsy();
           } else {

--- a/test/client/components/Participant.ListBody.spec.jsx
+++ b/test/client/components/Participant.ListBody.spec.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import ListBody from "@components/Participant/ListBody";
+import { shortParticipantData, longParticipantData } from "./testData";
+
+describe("Participant.ListBody.jsxのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンタリング", () => {
+      const tree = renderer
+        .create(<ListBody listData={shortParticipantData} />)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    it("Purposeコンポーネントのpurposeに、値を渡している", () => {
+      const purposeComponents = shallow(
+        <ListBody listData={shortParticipantData} />
+      ).find("Purpose");
+
+      shortParticipantData.forEach((data, index) => {
+        expect(purposeComponents.at(index).prop("purpose")).toBe(data.purpose);
+      });
+    });
+
+    it("StatusコンポーネントのisEntryに、値を渡している", () => {
+      const statusComponents = shallow(
+        <ListBody listData={shortParticipantData} />
+      ).find("Status");
+
+      statusComponents.forEach((node, index) => {
+        if (shortParticipantData[index].isEntry) {
+          expect(node.prop("isEntry")).toBeTruthy();
+        } else {
+          expect(node.prop("isEntry")).toBeFalsy();
+        }
+      });
+    });
+
+    describe("listDataにshortParticipantDataを指定した時", () => {
+      it("listItemの要素全てにcssクラス: buttomをもつ", () => {
+        const listItems = shallow(
+          <ListBody listData={shortParticipantData} />
+        ).find("li");
+
+        listItems.forEach(node => {
+          expect(node.hasClass("buttom")).toBeTruthy();
+        });
+      });
+    });
+
+    describe("listDataにlongParticipantDataを指定した時", () => {
+      it("最後の要素はcssクラス: buttomをもたない", () => {
+        const listItems = shallow(
+          <ListBody listData={longParticipantData} />
+        ).find("li");
+        const { length } = listItems;
+        listItems.forEach((node, index) => {
+          if (index === length - 1) {
+            expect(node.hasClass("buttom")).toBeFalsy();
+          } else {
+            expect(node.hasClass("buttom")).toBeTruthy();
+          }
+        });
+      });
+    });
+  });
+});

--- a/test/client/components/Participant.spec.jsx
+++ b/test/client/components/Participant.spec.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Participant from "@components/Participant";
+import ListHeader from "@components/Participant/ListHeader";
+import ListBody from "@components/Participant/ListBody";
+import { shortParticipantData } from "./testData";
+
+describe("Participantのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンダリング", () => {
+      const tree = renderer
+        .create(<Participant data={shortParticipantData} />)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    const participant = shallow(<Participant data={shortParticipantData} />);
+    it("cssクラス: flameをもつ", () => {
+      expect(participant.hasClass("flame")).toBeTruthy();
+    });
+
+    it("childrenは、cssクラス: listをもつ", () => {
+      expect(participant.children().hasClass("list")).toBeTruthy();
+    });
+
+    it("ListHeaderコンポーネントを使用している", () => {
+      expect(participant.contains(<ListHeader />)).toBeTruthy();
+    });
+
+    it("ListBodyコンポーネントのlistDataに、shortParticipantDataを渡している", () => {
+      expect(
+        participant.contains(<ListBody listData={shortParticipantData} />)
+      ).toBeTruthy();
+    });
+  });
+});

--- a/test/client/components/__snapshots__/Participant.ListBody.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.ListBody.spec.jsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Participant.ListBody.jsxのテスト スナップショット 正しいレンタリング 1`] = `
+<div
+  className="body"
+>
+  <ul>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name1
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus entry"
+      >
+        入
+      </div>
+    </li>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name2
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus entry"
+      >
+        入
+      </div>
+    </li>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name3
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus entry"
+      >
+        入
+      </div>
+    </li>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name4
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus entry"
+      >
+        入
+      </div>
+    </li>
+    <li
+      className="buttom"
+    >
+      <div
+        className="columnName border"
+      >
+        name5
+      </div>
+      <div
+        className="columnPurpose study border"
+      >
+        自習
+      </div>
+      <div
+        className="columnStatus exit"
+      >
+        退
+      </div>
+    </li>
+  </ul>
+</div>
+`;

--- a/test/client/components/__snapshots__/Participant.ListBody.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.ListBody.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Participant.ListBody.jsxのテスト スナップショット 正しいレンタリング 1`] = `
+exports[`Participant.ListBody.jsxのテスト スナップショット 正しいレンダリング 1`] = `
 <div
   className="body"
 >

--- a/test/client/components/__snapshots__/Participant.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.spec.jsx.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Participantのテスト スナップショット 正しいレンダリング 1`] = `
+<div
+  className="flame"
+>
+  <div
+    className="list"
+  >
+    <div
+      className="header"
+    >
+      <div
+        className="columnName border"
+      >
+        名前
+      </div>
+      <div
+        className="columnPurpose border"
+      >
+        目的
+      </div>
+      <div
+        className="columnStatus"
+      >
+        入退室
+      </div>
+    </div>
+    <div
+      className="body"
+    >
+      <ul>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name1
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus entry"
+          >
+            入
+          </div>
+        </li>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name2
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus entry"
+          >
+            入
+          </div>
+        </li>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name3
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus entry"
+          >
+            入
+          </div>
+        </li>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name4
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus entry"
+          >
+            入
+          </div>
+        </li>
+        <li
+          className="buttom"
+        >
+          <div
+            className="columnName border"
+          >
+            name5
+          </div>
+          <div
+            className="columnPurpose study border"
+          >
+            自習
+          </div>
+          <div
+            className="columnStatus exit"
+          >
+            退
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/test/client/components/testData.js
+++ b/test/client/components/testData.js
@@ -1,0 +1,70 @@
+export const shortParticipantData = [
+  {
+    name: "name1",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name2",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name3",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name4",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name5",
+    purpose: "study",
+    isEntry: false
+  }
+];
+
+export const longParticipantData = [
+  {
+    name: "name1",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name2",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name3",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name4",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name5",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name6",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name7",
+    purpose: "study",
+    isEntry: true
+  },
+  {
+    name: "name8",
+    purpose: "study",
+    isEntry: true
+  }
+];


### PR DESCRIPTION
## 該当issue
参加者一覧画面コンポーネント作成 #105

**1ファイルでコンポーネント作成しましたが大きくなったので分けました**

## 概要
- 一覧リストのリストボディ
- testフォルダに`.eslint.json`をtestフォルダに作成
- testで使用するデータをまとめた`testData.js`を作成