### PR TITLE
[change] MainFlameにコンテンツ領域枠を追加

### DIFF
--- a/src/client/components/MainFlame/index.jsx
+++ b/src/client/components/MainFlame/index.jsx
@@ -8,23 +8,38 @@ type PropType = {
 };
 
 /**
- * デフォルトクラス + 背景クラスを取得
+ * 背景クラスを取得
  * backgroundで無効な値が指定されたら、デフォルト背景を指定
  */
 function getClassName(type: string): string {
-  const { main, standard, work, study, meetUp, circle, exit, error } = styles;
-  if (type === "work") return `${main} ${work}`;
-  if (type === "study") return `${main} ${study}`;
-  if (type === "meetUp") return `${main} ${meetUp}`;
-  if (type === "circle") return `${main} ${circle}`;
-  if (type === "exit") return `${main} ${exit}`;
-  if (type === "error") return `${main} ${error}`;
-  return `${main} ${standard}`;
+  const {
+    mainFlame,
+    standard,
+    work,
+    study,
+    meetUp,
+    circle,
+    exit,
+    error
+  } = styles;
+
+  if (type === "work") return `${mainFlame} ${work}`;
+  if (type === "study") return `${mainFlame} ${study}`;
+  if (type === "meetUp") return `${mainFlame} ${meetUp}`;
+  if (type === "circle") return `${mainFlame} ${circle}`;
+  if (type === "exit") return `${mainFlame} ${exit}`;
+  if (type === "error") return `${mainFlame} ${error}`;
+
+  return `${mainFlame} ${standard}`;
 }
 
 function MainFlame(props: PropType): React.Node {
   const { children, type } = props;
   const { main } = styles;
-  return <main className={getClassName(type)}>{children}</main>;
+  return (
+    <main className={getClassName(type)}>
+      <div className={main}>{children}</div>
+    </main>
+  );
 }
 export default MainFlame;

--- a/src/client/components/MainFlame/style.css
+++ b/src/client/components/MainFlame/style.css
@@ -18,7 +18,7 @@
   border: 4px solid lightgray;
   border-radius: 8px;
   box-sizing: border-box;
-  box-shadow: 2px 0px 4px 0px grey;
+  box-shadow: 0px 0px 4px 1px grey;
 }
 
 /* デフォルト背景 */

--- a/src/client/components/MainFlame/style.css
+++ b/src/client/components/MainFlame/style.css
@@ -1,5 +1,5 @@
 @charset "utf-8";
-.main {
+.mainFlame {
   display: flex;
   position: relative;
   width: calc(100% - 170px);
@@ -7,6 +7,18 @@
   margin-left: 170px;
   box-sizing: border-box;
   padding: 40px;
+}
+
+.main {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  color: gray;
+  border: 4px solid lightgray;
+  border-radius: 8px;
+  box-sizing: border-box;
+  box-shadow: 2px 0px 4px 0px grey;
 }
 
 /* デフォルト背景 */

--- a/src/client/components/Participant/Purpose.jsx
+++ b/src/client/components/Participant/Purpose.jsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import styles from "./style.css";
 
 type PurposeType = {
-  purpose: string
+  purpose: string | void
 };
 
 function Purpose(props: PurposeType): React.Node {

--- a/src/client/components/Register/Header.jsx
+++ b/src/client/components/Register/Header.jsx
@@ -1,0 +1,46 @@
+// @flow
+import * as React from "react";
+import styles from "./style.css";
+
+type RegisterHeaderType = {
+  current: string
+};
+
+type ClassNameType = {
+  input?: string,
+  scan?: string,
+  completion?: string
+};
+
+function getClassName(current: string): ClassNameType {
+  const { active, disabled } = styles;
+
+  if (current === "input") {
+    return { input: active, scan: disabled, completion: disabled };
+  }
+  if (current === "scan") {
+    return { scan: active, completion: disabled };
+  }
+  if (current === "completion") {
+    return { completion: active };
+  }
+  return {};
+}
+
+function Header(props: RegisterHeaderType): React.Node {
+  const { current } = props;
+  const { header } = styles;
+  const { input, scan, completion } = getClassName(current);
+  return (
+    <ol className={header}>
+      <li className={input}>
+        1. 入力<span>&gt;</span>
+      </li>
+      <li className={scan}>
+        2. 読取<span>&gt;</span>
+      </li>
+      <li className={completion}>3. 完了</li>
+    </ol>
+  );
+}
+export default Header;

--- a/src/client/components/Register/Header.jsx
+++ b/src/client/components/Register/Header.jsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import styles from "./style.css";
 
 type RegisterHeaderType = {
-  current: string
+  current: string | void
 };
 
 type ClassNameType = {
@@ -28,7 +28,7 @@ function getClassName(current: string): ClassNameType {
 }
 
 function Header(props: RegisterHeaderType): React.Node {
-  const { current } = props;
+  const { current = "" } = props;
   const { header } = styles;
   const { input, scan, completion } = getClassName(current);
   return (

--- a/src/client/components/Register/style.css
+++ b/src/client/components/Register/style.css
@@ -1,0 +1,38 @@
+@charset "utf-8";
+.header {
+  display: table;
+  width: 100%;
+  height: 52px;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  border-bottom: 4px solid silver;
+  border-radius: 4px 4px 0px 0px;
+  box-sizing: border-box;
+}
+
+.header > li {
+  display: table-cell;
+  position: relative;
+  vertical-align: middle;
+  text-align: center;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.header > li > span {
+  display: flex;
+  position: absolute;
+  height: 100%;
+  top: 0;
+  right: 0;
+  align-items: center;
+}
+
+.active {
+  color: #ea0032;
+}
+
+.disabled {
+  color: lightgray;
+}

--- a/src/client/components/SingleButton/index.jsx
+++ b/src/client/components/SingleButton/index.jsx
@@ -1,0 +1,23 @@
+// @flow
+import * as React from "react";
+import styles from "./style.css";
+
+type SingleButtonType = {
+  text: string | void,
+  className: string | void,
+  onButtonClick: () => {} | void
+};
+
+function SingleButton(props: SingleButtonType): React.Node {
+  const { text = "", className = "default", onButtonClick } = props;
+  const { singleButton } = styles;
+
+  return (
+    <div className={singleButton}>
+      <button className={styles[className]} onClick={onButtonClick}>
+        {text}
+      </button>
+    </div>
+  );
+}
+export default SingleButton;

--- a/src/client/components/SingleButton/style.css
+++ b/src/client/components/SingleButton/style.css
@@ -1,0 +1,27 @@
+@charset "utf-8";
+.singleButton {
+  position: absolute;
+  width: 100%;
+  height: 70px;
+  bottom: 0;
+}
+
+.singleButton > button {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.default {
+  background-color: #00bcd4;
+  color: whitesmoke;
+}
+
+.next {
+  background-color: orange;
+  color: whitesmoke;
+}

--- a/test/client/components/MainFlame.spec.jsx
+++ b/test/client/components/MainFlame.spec.jsx
@@ -30,7 +30,7 @@ describe("MainFlame.jsxのテスト", () => {
       expect(mainFlame.name()).toBe("main");
     });
 
-    it("cssクラス: mainをもつ", () => {
+    it("main要素は、cssクラス: mainFlameをもつ", () => {
       const mainFlame = shallow(
         <MainFlame>
           <TestComponent />
@@ -40,8 +40,17 @@ describe("MainFlame.jsxのテスト", () => {
         mainFlame
           .find("main")
           .at(0)
-          .hasClass("main")
+          .hasClass("mainFlame")
       ).toBeTruthy();
+    });
+
+    it("main要素の子要素は、cssクラス: mainをもつ", () => {
+      const mainFlame = shallow(
+        <MainFlame>
+          <TestComponent />
+        </MainFlame>
+      );
+      expect(mainFlame.children().hasClass("main")).toBeTruthy();
     });
 
     it("指定したコンポーネントを子コンポーネントとしてもつ", () => {
@@ -50,8 +59,8 @@ describe("MainFlame.jsxのテスト", () => {
           <TestComponent />
         </MainFlame>
       );
-      expect(mainFlame.children().contains(TestComponent)).toBeTruthy();
-      expect(mainFlame.children().text()).toBe("test component");
+      expect(mainFlame.contains(TestComponent)).toBeTruthy();
+      expect(mainFlame.find("TestComponent").text()).toBe("test component");
     });
 
     describe("type: workを指定した時", () => {

--- a/test/client/components/Register.Header.spec.jsx
+++ b/test/client/components/Register.Header.spec.jsx
@@ -1,0 +1,141 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Header from "@components/Register/Header";
+
+describe("Register.Header.jsxのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンダリング", () => {
+      const tree = renderer.create(<Header />);
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    const base = shallow(<Header current="input" />);
+    const baseListItems = base.find("li");
+
+    it("ol要素はcssクラス: headerをもつ", () => {
+      expect(base.name()).toBe("ol");
+      expect(base.hasClass("header")).toBeTruthy();
+    });
+
+    it("ol要素はli要素を3つ持つ", () => {
+      expect(baseListItems).toHaveLength(3);
+    });
+
+    it("li要素の0番目の子要素は、[1. 入力>]と表示される", () => {
+      expect(baseListItems.at(0).text()).toBe("1. 入力>");
+    });
+
+    it("li要素の1番目の子要素は、[2. 読取>]と表示される", () => {
+      expect(baseListItems.at(1).text()).toBe("2. 読取>");
+    });
+
+    it("li要素の2番目の子要素は、[3. 完了]と表示される", () => {
+      expect(baseListItems.at(2).text()).toBe("3. 完了");
+    });
+
+    describe("currentにinputを指定した時", () => {
+      const selectedInput = shallow(<Header current="input" />).find("li");
+
+      it("li要素の0番目の子要素は、cssクラス: activeをもつ", () => {
+        expect(selectedInput.at(0).hasClass("active")).toBeTruthy();
+      });
+
+      it("li要素の1番目の子要素は、cssクラス: disabledをもつ", () => {
+        expect(selectedInput.at(1).hasClass("disabled")).toBeTruthy();
+      });
+
+      it("li要素の2番目の子要素は、cssクラス: disabledをもつ", () => {
+        expect(selectedInput.at(2).hasClass("disabled")).toBeTruthy();
+      });
+    });
+
+    describe("currentにscanを指定した時", () => {
+      const selectedScan = shallow(<Header current="scan" />).find("li");
+
+      it("li要素の0番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            selectedScan.at(0).props(),
+            "className"
+          )
+        ).toBeTruthy();
+        expect(selectedScan.at(0).props().className).toBeUndefined();
+      });
+
+      it("li要素の1番目の子要素は、cssクラス: activeをもつ", () => {
+        expect(selectedScan.at(1).hasClass("active")).toBeTruthy();
+      });
+
+      it("li要素の2番目の子要素は、cssクラス: disabledをもつ", () => {
+        expect(selectedScan.at(2).hasClass("disabled")).toBeTruthy();
+      });
+    });
+
+    describe("currentにcompletionを指定した時", () => {
+      const selectedCompletion = shallow(<Header current="completion" />).find(
+        "li"
+      );
+
+      it("li要素の0番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            selectedCompletion.at(0).props(),
+            "className"
+          )
+        ).toBeTruthy();
+        expect(selectedCompletion.at(0).props().className).toBeUndefined();
+      });
+
+      it("li要素の1番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            selectedCompletion.at(1).props(),
+            "className"
+          )
+        ).toBeTruthy();
+        expect(selectedCompletion.at(1).props().className).toBeUndefined();
+      });
+
+      it("li要素の2番目の子要素は、cssクラス: activeをもつ", () => {
+        expect(selectedCompletion.at(2).hasClass("active")).toBeTruthy();
+      });
+    });
+
+    describe("currentに値を指定しなかった時", () => {
+      const selectedCompletion = shallow(<Header />).find("li");
+
+      it("li要素の0番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            selectedCompletion.at(0).props(),
+            "className"
+          )
+        ).toBeTruthy();
+        expect(selectedCompletion.at(0).props().className).toBeUndefined();
+      });
+
+      it("li要素の1番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            selectedCompletion.at(1).props(),
+            "className"
+          )
+        ).toBeTruthy();
+        expect(selectedCompletion.at(1).props().className).toBeUndefined();
+      });
+
+      it("li要素の2番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            selectedCompletion.at(2).props(),
+            "className"
+          )
+        ).toBeTruthy();
+        expect(selectedCompletion.at(2).props().className).toBeUndefined();
+      });
+    });
+  });
+});

--- a/test/client/components/SingleButton.spec.jsx
+++ b/test/client/components/SingleButton.spec.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import SingleButton from "@components/SingleButton";
+
+describe("SingleButton.jsxのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンダリング", () => {
+      const tree = renderer.create(<SingleButton text="Single Button" />);
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    const onClick = jest.fn();
+    const defaultButton = shallow(
+      <SingleButton text="Single Button" onButtonClick={onClick} />
+    );
+    const button = defaultButton.find("button");
+    it("cssクラス: singleButtonをもつ", () => {
+      expect(defaultButton.hasClass("singleButton")).toBeTruthy();
+    });
+
+    it("button要素はcssクラス: defaultをもつ", () => {
+      expect(button.hasClass("default")).toBeTruthy();
+    });
+
+    it("textに渡した文字列が表示される", () => {
+      expect(button.text("Single Button")).toBeTruthy();
+    });
+
+    it("クリックすると、onButtonClickに渡した関数が実行される", () => {
+      button.simulate("click");
+      expect(onClick).toBeCalled();
+    });
+
+    describe("classNameにnextと指定した時", () => {
+      it("button要素はcssクラス: nextをもつ", () => {
+        const nextButton = shallow(<SingleButton className="next" />);
+        expect(nextButton.find("button").hasClass("next")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/test/client/components/__snapshots__/MainFlame.spec.jsx.snap
+++ b/test/client/components/__snapshots__/MainFlame.spec.jsx.snap
@@ -2,10 +2,14 @@
 
 exports[`MainFlame.jsxのテスト スナップショット 正しいレンダリング 1`] = `
 <main
-  className="main standard"
+  className="mainFlame standard"
 >
-  <div>
-    test component
+  <div
+    className="main"
+  >
+    <div>
+      test component
+    </div>
   </div>
 </main>
 `;

--- a/test/client/components/__snapshots__/Participant.Status.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Participant.Status.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Participant.Status.jsxjのテスト スナップショット 正しいレンタリング 1`] = `
+exports[`Participant.Status.jsxのテスト スナップショット 正しいレンダリング 1`] = `
 <div
   className="columnStatus entry"
 >

--- a/test/client/components/__snapshots__/Register.Header.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Register.Header.spec.jsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Register.Header.jsxのテスト スナップショット 正しいレンダリング 1`] = `
+<ol
+  className="header"
+>
+  <li
+    className={undefined}
+  >
+    1. 入力
+    <span>
+      &gt;
+    </span>
+  </li>
+  <li
+    className={undefined}
+  >
+    2. 読取
+    <span>
+      &gt;
+    </span>
+  </li>
+  <li
+    className={undefined}
+  >
+    3. 完了
+  </li>
+</ol>
+`;

--- a/test/client/components/__snapshots__/SingleButton.spec.jsx.snap
+++ b/test/client/components/__snapshots__/SingleButton.spec.jsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SingleButton.jsxのテスト スナップショット 正しいレンダリング 1`] = `
+<div
+  className="singleButton"
+>
+  <button
+    className="default"
+    onClick={undefined}
+  >
+    Single Button
+  </button>
+</div>
+`;


### PR DESCRIPTION
## 関連issue
ユーザ登録画面コンポーネント作成 #106

## 変更点
- マスコット画像コンポーネントを今回は実装しない方針に変更(一旦機能を作ってから追加)
  - 機能実装優先のため。
  - 後でも実装の影響は少ないとの判断
- MainFlameコンポーネントはコンテンツ背景枠用のコンポーネントと定義したが、コンテンツ枠も含めた方が使いやすいメリットもあり