### PR TITLE
[change] 目的選択画面のボタンをクリックした時、アウトラインが表示されないように修正

### DIFF
--- a/src/client/components/Common/index.jsx
+++ b/src/client/components/Common/index.jsx
@@ -1,0 +1,45 @@
+// @flow
+import * as React from "react";
+import SingleButton from "@components/SingleButton";
+import styles from "./style.css";
+
+type CommonType = {
+  type: string | void,
+  text: string,
+  subText: string | void,
+  buttonText: string,
+  buttonClass: string | void,
+  onButtonClick: (e: SyntheticEvent<HTMLButtonElement>) => {}
+};
+
+function Common(props: CommonType): React.Node {
+  const { type, text, subText, buttonText, buttonClass, onButtonClick } = props;
+  const { textArea, main, date, sub } = styles;
+  const dateTextNode =
+    type === "date" ? (
+      <div className={date}>{new Date().toLocaleString()}</div>
+    ) : (
+      undefined
+    );
+  const subTextNode = subText ? (
+    <div className={sub}>{subText}</div>
+  ) : (
+    undefined
+  );
+
+  return (
+    <div>
+      <div className={textArea}>
+        <div className={main}>{text}</div>
+        {dateTextNode}
+        {subTextNode}
+      </div>
+      <SingleButton
+        text={buttonText}
+        className={buttonClass}
+        onButtonClick={onButtonClick}
+      />
+    </div>
+  );
+}
+export default Common;

--- a/src/client/components/Common/style.css
+++ b/src/client/components/Common/style.css
@@ -1,0 +1,30 @@
+@charset "utf-8";
+.textArea {
+  position: relative;
+  height: calc(100% - 70px);
+}
+
+.main {
+  display: flex;
+  height: 60%;
+  justify-content: center;
+  align-items: flex-end;
+  font-size: 36px;
+  font-weight: bold;
+}
+
+.date {
+  display: flex;
+  height: 40%;
+  justify-content: center;
+  font-size: 20px;
+  padding-top: 10px;
+  box-sizing: border-box;
+}
+
+.sub {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  font-size: 24px;
+}

--- a/src/client/components/MainFlame/index.jsx
+++ b/src/client/components/MainFlame/index.jsx
@@ -4,14 +4,14 @@ import styles from "./style.css";
 
 type PropType = {
   children: React.Node,
-  type: string
+  type: string | void
 };
 
 /**
  * 背景クラスを取得
  * backgroundで無効な値が指定されたら、デフォルト背景を指定
  */
-function getClassName(type: string): string {
+function getClassName(type: string = ""): string {
   const {
     mainFlame,
     standard,

--- a/src/client/components/Participant/Purpose.jsx
+++ b/src/client/components/Participant/Purpose.jsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import styles from "./style.css";
 
 type PurposeType = {
-  purpose: string | void
+  purpose: string
 };
 
 function Purpose(props: PurposeType): React.Node {
@@ -31,7 +31,7 @@ function Purpose(props: PurposeType): React.Node {
   }
 
   return (
-    <div className={`${columnPurpose} ${background} ${border}`}>{value}</div>
+    <div className={`${columnPurpose} ${border} ${background}`}>{value}</div>
   );
 }
 export default Purpose;

--- a/src/client/components/Purpose/style.css
+++ b/src/client/components/Purpose/style.css
@@ -15,6 +15,7 @@
   font-weight: bold;
   border: none;
   box-sizing: border-box;
+  outline: none;
 }
 
 .meetUp {

--- a/src/client/components/Register/RegisterInput.jsx
+++ b/src/client/components/Register/RegisterInput.jsx
@@ -22,12 +22,12 @@ function RegisterInput(props: RegisterInputType): React.Node {
   const {
     firstNameValue,
     firstNameError,
+    onFirstNameChange,
     lastNameValue,
     lastNameError,
+    onLastNameChange,
     emailValue,
     emailError,
-    onFirstNameChange,
-    onLastNameChange,
     onEmailChange,
     onClickNextButton,
     onSubmitForm

--- a/src/client/components/Register/style.css
+++ b/src/client/components/Register/style.css
@@ -146,6 +146,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 48px;
+  font-size: 36px;
   font-weight: bold;
 }

--- a/src/client/components/storybook/config.js
+++ b/src/client/components/storybook/config.js
@@ -5,6 +5,7 @@ function loadStories() {
   require("./stories/top");
   require("./stories/mainFlame");
   require("./stories/purpose");
+  require("./stories/common");
   require("./stories/participant");
   require("./stories/register");
 }

--- a/src/client/components/storybook/stories/common.jsx
+++ b/src/client/components/storybook/stories/common.jsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import MainFlame from "@components/MainFlame";
+import Common from "@components/Common";
+import DummyContainer from "../DummyContainer";
+
+storiesOf("Common", module)
+  .add("サブテキスト有", () => (
+    <DummyContainer>
+      <MainFlame>
+        <Common
+          text="メインテキスト"
+          subText="サブテキスト"
+          buttonText="ボタン"
+          buttonClass="default"
+          onButtonClick={action("click")}
+        />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("サブテキスト無", () => (
+    <DummyContainer>
+      <MainFlame>
+        <Common
+          text="メインテキスト"
+          buttonText="ボタン"
+          buttonClass="default"
+          onButtonClick={action("click")}
+        />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("目的選択後", () => (
+    <DummyContainer>
+      <MainFlame>
+        <Common
+          type="date"
+          text="Have a Good Time !!"
+          subText="入室処理が完了しました"
+          buttonText="Topへ戻る"
+          buttonClass="default"
+          onButtonClick={action("click")}
+        />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("退出処理後", () => (
+    <DummyContainer>
+      <MainFlame>
+        <Common
+          type="date"
+          text="お疲れ様でした"
+          subText="退出処理が完了しました"
+          buttonText="Topへ戻る"
+          buttonClass="default"
+          onButtonClick={action("click")}
+        />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("未登録時", () => (
+    <DummyContainer>
+      <MainFlame>
+        <Common
+          text="404 Not Found"
+          subText="使用するには登録が必要です"
+          buttonText="登録はこちら"
+          buttonClass="next"
+          onButtonClick={action("click")}
+        />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("リクエストエラー", () => (
+    <DummyContainer>
+      <MainFlame>
+        <Common
+          text="400 Bad Request"
+          subText="(エラーメッセージがあれば表示する)"
+          buttonText="Topへ戻る"
+          buttonClass="default"
+          onButtonClick={action("click")}
+        />
+      </MainFlame>
+    </DummyContainer>
+  ))
+  .add("サーバエラー", () => (
+    <DummyContainer>
+      <MainFlame>
+        <Common
+          text="500 Internal Server Error"
+          subText="管理者に問い合わせて下さい"
+          buttonText="Topへ戻る"
+          buttonClass="default"
+          onButtonClick={action("click")}
+        />
+      </MainFlame>
+    </DummyContainer>
+  ));

--- a/test/client/components/Common.spec.jsx
+++ b/test/client/components/Common.spec.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import Common from "@components/Common";
+
+// Dateクラスをmock化
+jest
+  .spyOn(Date.prototype, "toLocaleString")
+  .mockReturnValue("1970/01/01 00:00:00");
+
+const fn = () => {};
+const factory = (values = {}) => {
+  const { type, subText } = values;
+  return shallow(
+    <Common
+      type={type}
+      text="テキスト"
+      subText={subText}
+      buttonText="ボタン"
+      buttonClass="default"
+      onButtonClick={fn}
+    />
+  );
+};
+
+describe("Common.jsxのテスト", () => {
+  describe("スナップショット", () => {
+    it("正しいレンダリング", () => {
+      const tree = renderer.create(
+        <Common
+          type="date"
+          text="テキスト"
+          subText="サブテキスト"
+          buttonText="ボタン"
+          buttonClass="default"
+          onButtonClick={() => {}}
+        />
+      );
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe("コンポーネントのテスト", () => {
+    const defaultCommon = factory();
+
+    it("typeがdateの時、時刻が表示されている", () => {
+      const common = factory({ type: "date" });
+      expect(common.find(".date").text()).toBe("1970/01/01 00:00:00");
+    });
+
+    it("typeが指定されていない時、時刻は表示されていない", () => {
+      expect(defaultCommon.find(".date").exists()).toBeFalsy();
+    });
+
+    it("typeにdate以外が指定されている時、時刻は表示されていない", () => {
+      const common = factory({ type: "hoge" });
+      expect(common.find(".date").exists()).toBeFalsy();
+    });
+
+    it("textに渡した値が表示されている", () => {
+      expect(defaultCommon.find(".main").text()).toBe("テキスト");
+    });
+
+    it("subTextが指定されている時、subTextに渡した値が表示されている", () => {
+      const common = factory({ subText: "サブテキスト" });
+      expect(common.exists(".sub")).toBeTruthy();
+      expect(common.find(".sub").text()).toBe("サブテキスト");
+    });
+
+    it("subTextが指定されていない場合、表示されていない", () => {
+      expect(defaultCommon.find(".sub").exists()).toBeFalsy();
+    });
+
+    it("SingleButtonコンポーネントに、buttonText, buttonClass, onButtonClickに指定した値が正常に渡されている", () => {
+      const singleButton = factory()
+        .find("SingleButton")
+        .props();
+
+      expect(singleButton.text).toBe("ボタン");
+      expect(singleButton.className).toBe("default");
+      expect(singleButton.onButtonClick).toBe(fn);
+    });
+  });
+});

--- a/test/client/components/MainFlame.spec.jsx
+++ b/test/client/components/MainFlame.spec.jsx
@@ -1,154 +1,74 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow, mount } from "enzyme";
+import { shallow } from "enzyme";
 import MainFlame from "@components/MainFlame";
-
-// eslint-disable-next-line flowtype/require-return-type
-const TestComponent = () => <div>test component</div>;
 
 describe("MainFlame.jsxのテスト", () => {
   describe("スナップショット", () => {
     it("正しいレンダリング", () => {
-      const tree = renderer
-        .create(
-          <MainFlame>
-            <TestComponent />
-          </MainFlame>
-        )
-        .toJSON();
+      const tree = renderer.create(<MainFlame>children</MainFlame>).toJSON();
       expect(tree).toMatchSnapshot();
     });
   });
 
   describe("コンポーネントのテスト", () => {
-    it("main要素をもつ", () => {
-      const mainFlame = shallow(
-        <MainFlame>
-          <TestComponent />
-        </MainFlame>
-      );
-      expect(mainFlame.name()).toBe("main");
-    });
-
-    it("main要素は、cssクラス: mainFlameをもつ", () => {
-      const mainFlame = shallow(
-        <MainFlame>
-          <TestComponent />
-        </MainFlame>
-      );
+    it("子要素が表示されている", () => {
+      // 文字の時
       expect(
-        mainFlame
-          .find("main")
-          .at(0)
-          .hasClass("mainFlame")
+        shallow(<MainFlame>children</MainFlame>)
+          .find(".main")
+          .text()
+      ).toBe("children");
+      // JSXの時
+      expect(
+        shallow(
+          <MainFlame>
+            <div>children</div>
+          </MainFlame>
+        )
+          .find(".main")
+          .contains(<div>children</div>)
       ).toBeTruthy();
     });
 
-    it("main要素の子要素は、cssクラス: mainをもつ", () => {
-      const mainFlame = shallow(
-        <MainFlame>
-          <TestComponent />
-        </MainFlame>
-      );
-      expect(mainFlame.children().hasClass("main")).toBeTruthy();
+    it("typeにworkを指定した時、main要素はcssクラス: workを持つ", () => {
+      const flame = shallow(<MainFlame type="work">test</MainFlame>);
+      expect(flame.find("main").hasClass("work")).toBeTruthy();
     });
 
-    it("指定したコンポーネントを子コンポーネントとしてもつ", () => {
-      const mainFlame = mount(
-        <MainFlame>
-          <TestComponent />
-        </MainFlame>
-      );
-      expect(mainFlame.contains(TestComponent)).toBeTruthy();
-      expect(mainFlame.find("TestComponent").text()).toBe("test component");
+    it("typeにstudyを指定した時、main要素はcssクラス: studyを持つ", () => {
+      const flame = shallow(<MainFlame type="study">test</MainFlame>);
+      expect(flame.find("main").hasClass("study")).toBeTruthy();
     });
 
-    describe("type: workを指定した時", () => {
-      it("cssクラス: workをもつ", () => {
-        const mainFlame = shallow(
-          <MainFlame type="work">
-            <TestComponent />
-          </MainFlame>
-        );
-        expect(mainFlame.find("main").hasClass("work")).toBeTruthy();
-      });
+    it("typeにmeetUpを指定した時、main要素はcssクラス: meetUpを持つ", () => {
+      const flame = shallow(<MainFlame type="meetUp">test</MainFlame>);
+      expect(flame.find("main").hasClass("meetUp")).toBeTruthy();
     });
 
-    describe("type: studyを指定した時", () => {
-      it("cssクラス: studyをもつ", () => {
-        const mainFlame = shallow(
-          <MainFlame type="study">
-            <TestComponent />
-          </MainFlame>
-        );
-        expect(mainFlame.find("main").hasClass("study")).toBeTruthy();
-      });
+    it("typeにcircleを指定した時、main要素はcssクラス: circleを持つ", () => {
+      const flame = shallow(<MainFlame type="circle">test</MainFlame>);
+      expect(flame.find("main").hasClass("circle")).toBeTruthy();
     });
 
-    describe("type: meetUpを指定した時", () => {
-      it("cssクラス: meetUpをもつ", () => {
-        const mainFlame = shallow(
-          <MainFlame type="meetUp">
-            <TestComponent />
-          </MainFlame>
-        );
-        expect(mainFlame.find("main").hasClass("meetUp")).toBeTruthy();
-      });
+    it("typeにexitを指定した時、main要素はcssクラス: exitを持つ", () => {
+      const flame = shallow(<MainFlame type="exit">test</MainFlame>);
+      expect(flame.find("main").hasClass("exit")).toBeTruthy();
     });
 
-    describe("type: circleを指定した時", () => {
-      it("cssクラス: circleをもつ", () => {
-        const mainFlame = shallow(
-          <MainFlame type="circle">
-            <TestComponent />
-          </MainFlame>
-        );
-        expect(mainFlame.find("main").hasClass("circle")).toBeTruthy();
-      });
+    it("typeにerrorを指定した時、main要素はcssクラス: errorを持つ", () => {
+      const flame = shallow(<MainFlame type="error">test</MainFlame>);
+      expect(flame.find("main").hasClass("error")).toBeTruthy();
     });
 
-    describe("type: exitを指定した時", () => {
-      it("cssクラス: exitをもつ", () => {
-        const mainFlame = shallow(
-          <MainFlame type="exit">
-            <TestComponent />
-          </MainFlame>
-        );
-        expect(mainFlame.find("main").hasClass("exit")).toBeTruthy();
-      });
+    it("typeに上記以外を指定した時、main要素はcssクラス: standardを持つ", () => {
+      const flame = shallow(<MainFlame type="test">test</MainFlame>);
+      expect(flame.find("main").hasClass("standard")).toBeTruthy();
     });
 
-    describe("type: errorを指定した時", () => {
-      it("cssクラス: errorをもつ", () => {
-        const mainFlame = shallow(
-          <MainFlame type="error">
-            <TestComponent />
-          </MainFlame>
-        );
-        expect(mainFlame.find("main").hasClass("error")).toBeTruthy();
-      });
-    });
-
-    describe("typeに上記以外を指定した時", () => {
-      it("cssクラス: standardをもつ", () => {
-        const mainFlame = shallow(
-          <MainFlame type="standard">
-            <TestComponent />
-          </MainFlame>
-        );
-        expect(mainFlame.find("main").hasClass("standard")).toBeTruthy();
-      });
-    });
-
-    describe("typeを指定しない時", () => {
-      it("cssクラス: standardをもつ", () => {
-        const mainFlame = shallow(
-          <MainFlame type="standard">
-            <TestComponent />
-          </MainFlame>
-        );
-        expect(mainFlame.find("main").hasClass("standard")).toBeTruthy();
-      });
+    it("typeに値を指定しない時、main要素はcssクラス: standardを持つ", () => {
+      const flame = shallow(<MainFlame>test</MainFlame>);
+      expect(flame.find("main").hasClass("standard")).toBeTruthy();
     });
   });
 });

--- a/test/client/components/Menu.spec.jsx
+++ b/test/client/components/Menu.spec.jsx
@@ -15,89 +15,72 @@ describe("Menu.jsxのテスト", () => {
 
   describe("コンポーネントのテスト", () => {
     it("button要素を3つもつ", () => {
-      const menu = shallow(<Menu />);
-      const buttons = menu.find("button");
+      const buttons = shallow(<Menu />).find("button");
       expect(buttons).toHaveLength(3);
       expect(buttons.at(0).text()).toBe("入退室処理");
       expect(buttons.at(1).text()).toBe("ユーザ登録");
       expect(buttons.at(2).text()).toBe("利用者一覧");
     });
 
-    describe("currentに「入退室処理」を指定する", () => {
-      it("「入退室処理」ボタンにcssクラス: selectedをもつ", () => {
-        const menu = shallow(<Menu current="入退室処理" />);
-        const buttons = menu.find("button");
-        expect(buttons.at(0).hasClass("selected")).toBeTruthy();
-        expect(buttons.at(1).hasClass("selected")).toBeFalsy();
-        expect(buttons.at(2).hasClass("selected")).toBeFalsy();
-      });
+    it("currentに「入退室処理」を指定した時、「入退室処理」ボタンはcssクラス: selectedを持つ", () => {
+      const buttons = shallow(<Menu current="入退室処理" />).find("button");
+      expect(buttons.at(0).hasClass("selected")).toBeTruthy();
+      expect(buttons.at(1).hasClass("selected")).toBeFalsy();
+      expect(buttons.at(2).hasClass("selected")).toBeFalsy();
     });
 
-    describe("currentに「ユーザ登録」を指定する", () => {
-      it("「ユーザ登録」ボタンにcssクラス: selectedをもつ", () => {});
-      const menu = shallow(<Menu current="ユーザ登録" />);
-      const buttons = menu.find("button");
+    it("currentに「ユーザ登録」を指定した時、「ユーザ登録」ボタンはcssクラス: selectedを持つ", () => {
+      const buttons = shallow(<Menu current="ユーザ登録" />).find("button");
       expect(buttons.at(0).hasClass("selected")).toBeFalsy();
       expect(buttons.at(1).hasClass("selected")).toBeTruthy();
       expect(buttons.at(2).hasClass("selected")).toBeFalsy();
     });
 
-    describe("currentに「利用者一覧」を指定する", () => {
-      it("「利用者一覧」ボタンにcssクラス: selectedをもつ", () => {
-        const menu = shallow(<Menu current="利用者一覧" />);
-        const buttons = menu.find("button");
-        expect(buttons.at(0).hasClass("selected")).toBeFalsy();
-        expect(buttons.at(1).hasClass("selected")).toBeFalsy();
-        expect(buttons.at(2).hasClass("selected")).toBeTruthy();
-      });
+    it("currentに「利用者一覧」を指定した時、「利用者一覧」ボタンにcssクラス: selectedを持つ", () => {
+      const buttons = shallow(<Menu current="利用者一覧" />).find("button");
+      expect(buttons.at(0).hasClass("selected")).toBeFalsy();
+      expect(buttons.at(1).hasClass("selected")).toBeFalsy();
+      expect(buttons.at(2).hasClass("selected")).toBeTruthy();
     });
 
-    describe("currentに何も指定しない", () => {
-      it("どのボタンもcssクラス: selectedを持たない", () => {
-        const menu = shallow(<Menu current="" />);
-        const buttons = menu.find("button");
-        expect(buttons.at(0).hasClass("selected")).toBeFalsy();
-        expect(buttons.at(1).hasClass("selected")).toBeFalsy();
-        expect(buttons.at(2).hasClass("selected")).toBeFalsy();
-      });
+    it("currentに何も指定しない時、どのボタンもcssクラス: selectedを持たない", () => {
+      const buttons = shallow(<Menu current="" />).find("button");
+      expect(buttons.at(0).hasClass("selected")).toBeFalsy();
+      expect(buttons.at(1).hasClass("selected")).toBeFalsy();
+      expect(buttons.at(2).hasClass("selected")).toBeFalsy();
     });
 
-    describe("buttonをクリック", () => {
+    describe("buttonをクリック時", () => {
       const onButtonClick = jest.fn();
       let menu;
+
       beforeEach(() => {
         menu = shallow(<Menu onButtonClick={onButtonClick} />);
         onButtonClick.mockReset();
       });
 
-      describe("「入退室処理」をクリックする", () => {
-        it("引数に'入退室処理'が渡される", () => {
-          menu
-            .find("button")
-            .at(0)
-            .simulate("click");
-          expect(onButtonClick.mock.calls[0][0]).toBe("入退室処理");
-        });
+      it("「入退室処理」をクリックした時、引数に'入退室処理'が渡される", () => {
+        menu
+          .find("button")
+          .at(0)
+          .simulate("click");
+        expect(onButtonClick.mock.calls[0][0]).toBe("入退室処理");
       });
 
-      describe("「ユーザ登録」をクリックする", () => {
-        it("引数に'ユーザ登録'が渡される", () => {
-          menu
-            .find("button")
-            .at(1)
-            .simulate("click");
-          expect(onButtonClick.mock.calls[0][0]).toBe("ユーザ登録");
-        });
+      it("「ユーザ登録」をクリックした時、引数に'ユーザ登録'が渡される", () => {
+        menu
+          .find("button")
+          .at(1)
+          .simulate("click");
+        expect(onButtonClick.mock.calls[0][0]).toBe("ユーザ登録");
       });
 
-      describe("「利用者一覧」をクリックする", () => {
-        it("引数に'利用者一覧'が渡される", () => {
-          menu
-            .find("button")
-            .at(2)
-            .simulate("click");
-          expect(onButtonClick.mock.calls[0][0]).toBe("利用者一覧");
-        });
+      it("「利用者一覧」をクリックした時、引数に'利用者一覧'が渡される", () => {
+        menu
+          .find("button")
+          .at(2)
+          .simulate("click");
+        expect(onButtonClick.mock.calls[0][0]).toBe("利用者一覧");
       });
     });
   });

--- a/test/client/components/Participant/ListBody.spec.jsx
+++ b/test/client/components/Participant/ListBody.spec.jsx
@@ -17,10 +17,11 @@ describe("Participant.ListBody.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    const listBody = shallow(<ListBody listData={shortParticipantData} />);
-    const listItems = listBody.find("li");
+    const listItems = shallow(
+      <ListBody listData={shortParticipantData} />
+    ).find("li");
 
-    it("各<li>のname項目には、渡されたdataのnameの値が表示されている", () => {
+    it("各li要素には、listDataで渡されたnameの値が表示されている", () => {
       listItems.forEach((node, index) => {
         expect(node.find(".columnName").text()).toBe(
           shortParticipantData[index].name
@@ -28,7 +29,7 @@ describe("Participant.ListBody.jsxのテスト", () => {
       });
     });
 
-    it("Purposeコンポーネントのpurposeに、値を渡している", () => {
+    it("Purposeコンポーネントのpurposeに、listDataで渡されたpurposeの値が渡されている", () => {
       listItems.forEach((node, index) =>
         expect(
           node.contains(
@@ -38,7 +39,7 @@ describe("Participant.ListBody.jsxのテスト", () => {
       );
     });
 
-    it("StatusコンポーネントのisEntryに、値を渡している", () => {
+    it("StatusコンポーネントのisEntryに、listDataで渡されたisEntryの値が渡されている", () => {
       listItems.forEach((node, index) =>
         expect(
           node.contains(
@@ -48,25 +49,24 @@ describe("Participant.ListBody.jsxのテスト", () => {
       );
     });
 
-    it("listItemの要素全てにcssクラス: buttomをもつ", () => {
+    it("listDataの長さが5以下の時、全ての要素はcssクラス: buttomを持つ", () => {
       listItems.forEach(node => {
         expect(node.hasClass("buttom")).toBeTruthy();
       });
     });
 
-    describe("listDataにlongParticipantDataを指定した時", () => {
-      it("最後の要素はcssクラス: buttomをもたない", () => {
-        const longListItems = shallow(
-          <ListBody listData={longParticipantData} />
-        ).find("li");
-        const { length } = longListItems;
-        longListItems.forEach((node, index) => {
-          if (index === length - 1) {
-            expect(node.hasClass("buttom")).toBeFalsy();
-          } else {
-            expect(node.hasClass("buttom")).toBeTruthy();
-          }
-        });
+    it("listDataの長さが6以上の時、最後の要素のみcssクラス: buttomを持たない", () => {
+      const longListItems = shallow(
+        <ListBody listData={longParticipantData} />
+      ).find("li");
+      const { length } = longListItems;
+
+      longListItems.forEach((node, index) => {
+        if (index === length - 1) {
+          expect(node.hasClass("buttom")).toBeFalsy();
+        } else {
+          expect(node.hasClass("buttom")).toBeTruthy();
+        }
       });
     });
   });

--- a/test/client/components/Participant/ListHeader.spec.jsx
+++ b/test/client/components/Participant/ListHeader.spec.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow } from "enzyme";
 import ListHeader from "@components/Participant/ListHeader";
 
 describe("Participant.ListHeader.jsxのテスト", () => {
@@ -8,38 +7,6 @@ describe("Participant.ListHeader.jsxのテスト", () => {
     it("正しいレンダリング", () => {
       const tree = renderer.create(<ListHeader />).toJSON();
       expect(tree).toMatchSnapshot();
-    });
-  });
-
-  describe("コンポーネントのテスト", () => {
-    const header = shallow(<ListHeader />);
-    const children = header.find(".header > div");
-    it("cssクラス: headerをもつ", () => {
-      expect(header.hasClass("header")).toBeTruthy();
-    });
-
-    it("cssクラス: headerをもつdiv要素は、子要素にdiv要素を3つもつ", () => {
-      expect(children).toHaveLength(3);
-    });
-
-    it("cssクラス: headerをもつdivの1つめの子要素は、項目名が[名前]", () => {
-      const child = children.at(0);
-      expect(child.hasClass("columnName")).toBeTruthy();
-      expect(child.hasClass("border")).toBeTruthy();
-      expect(child.text("名前")).toBeTruthy();
-    });
-
-    it("cssクラス: headerをもつdivの2つめの子要素は、項目名が[目的]", () => {
-      const child = children.at(1);
-      expect(child.hasClass("columnPurpose")).toBeTruthy();
-      expect(child.hasClass("border")).toBeTruthy();
-      expect(child.text("目的")).toBeTruthy();
-    });
-
-    it("cssクラス: headerをもつdivの3つめの子要素は、項目名が[入退室]", () => {
-      const child = children.at(2);
-      expect(child.hasClass("columnStatus")).toBeTruthy();
-      expect(child.text("入退室")).toBeTruthy();
     });
   });
 });

--- a/test/client/components/Participant/Purpose.spec.jsx
+++ b/test/client/components/Participant/Purpose.spec.jsx
@@ -12,50 +12,34 @@ describe("Participant.Purpose.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    it("cssクラス: columnPurpose, borderをもつ", () => {
-      const purpose = shallow(<Purpose />);
-      expect(purpose.hasClass("columnPurpose")).toBeTruthy();
-      expect(purpose.hasClass("border")).toBeTruthy();
+    it("purposeにstudyを指定した時、共通cssクラス以外にstudyを持ち、自習と表示される", () => {
+      const purpose = shallow(<Purpose purpose="study" />);
+      expect(purpose.hasClass("study")).toBeTruthy();
+      expect(purpose.text("自習")).toBeTruthy();
     });
 
-    describe("purposeにstudyを指定した時", () => {
-      it("共通のcssクラスの他にstudyをもち、自習と表示される", () => {
-        const purpose = shallow(<Purpose purpose="study" />);
-        expect(purpose.hasClass("columnPurpose")).toBeTruthy();
-        expect(purpose.hasClass("border")).toBeTruthy();
-        expect(purpose.hasClass("study")).toBeTruthy();
-        expect(purpose.text("自習")).toBeTruthy();
-      });
+    it("purposeにmeetUpを指定した時、共通cssクラス以外にmeetUpを持ち、勉強会と表示される", () => {
+      const purpose = shallow(<Purpose purpose="meetUp" />);
+      expect(purpose.hasClass("meetUp")).toBeTruthy();
+      expect(purpose.text("勉強会")).toBeTruthy();
     });
 
-    describe("purposeにmeetUpを指定した時", () => {
-      it("共通のcssクラスの他にmeetUpをもち、勉強会と表示される", () => {
-        const purpose = shallow(<Purpose purpose="meetUp" />);
-        expect(purpose.hasClass("columnPurpose")).toBeTruthy();
-        expect(purpose.hasClass("border")).toBeTruthy();
-        expect(purpose.hasClass("meetUp")).toBeTruthy();
-        expect(purpose.text("勉強会")).toBeTruthy();
-      });
+    it("purposeにworkを指定した時、共通cssクラス以外にworkを持ち、仕事と表示される", () => {
+      const purpose = shallow(<Purpose purpose="work" />);
+      expect(purpose.hasClass("work")).toBeTruthy();
+      expect(purpose.text("仕事")).toBeTruthy();
     });
 
-    describe("purposeにworkを指定した時", () => {
-      it("共通のcssクラスの他にworkをもち、仕事と表示される", () => {
-        const purpose = shallow(<Purpose purpose="work" />);
-        expect(purpose.hasClass("columnPurpose")).toBeTruthy();
-        expect(purpose.hasClass("border")).toBeTruthy();
-        expect(purpose.hasClass("work")).toBeTruthy();
-        expect(purpose.text("仕事")).toBeTruthy();
-      });
+    it("purposeにcircleを指定した時、共通cssクラス以外にcircleを持ち、サークルと表示される", () => {
+      const purpose = shallow(<Purpose purpose="circle" />);
+      expect(purpose.hasClass("circle")).toBeTruthy();
+      expect(purpose.text("サークル")).toBeTruthy();
     });
 
-    describe("purposeにcircleを指定した時", () => {
-      it("共通のcssクラスの他にcircleをもち、サークルと表示される", () => {
-        const purpose = shallow(<Purpose purpose="circle" />);
-        expect(purpose.hasClass("columnPurpose")).toBeTruthy();
-        expect(purpose.hasClass("border")).toBeTruthy();
-        expect(purpose.hasClass("circle")).toBeTruthy();
-        expect(purpose.text("サークル")).toBeTruthy();
-      });
+    it("purposeに上記以外の値を指定した時、共通cssクラスのみを持ち、表示される文字はない", () => {
+      const purpose = shallow(<Purpose purpose="test" />);
+      expect(purpose.prop("className")).toBe("columnPurpose border ");
+      expect(purpose.text()).toBe("");
     });
   });
 });

--- a/test/client/components/Participant/Status.spec.jsx
+++ b/test/client/components/Participant/Status.spec.jsx
@@ -12,22 +12,16 @@ describe("Participant.Status.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    describe("属性にisEntryを指定した時", () => {
-      it("共通のcssクラスの他にentryをもち、入と表示される", () => {
-        const status = shallow(<Status isEntry />);
-        expect(status.hasClass("columnStatus")).toBeTruthy();
-        expect(status.hasClass("entry")).toBeTruthy();
-        expect(status.text("入")).toBeTruthy();
-      });
+    it("isEntryを指定した時、共通cssクラス以外にentryを持ち、入と表示される", () => {
+      const status = shallow(<Status isEntry />);
+      expect(status.hasClass("entry")).toBeTruthy();
+      expect(status.text("入")).toBeTruthy();
     });
 
-    describe("属性にisEntryを指定しない時", () => {
-      it("共通のcssクラスの他にexitをもち、退と表示される", () => {
-        const status = shallow(<Status />);
-        expect(status.hasClass("columnStatus")).toBeTruthy();
-        expect(status.hasClass("exit")).toBeTruthy();
-        expect(status.text("退")).toBeTruthy();
-      });
+    it("isEntryを指定しない時、共通cssクラス以外にexitを持ち、退と表示される", () => {
+      const status = shallow(<Status />);
+      expect(status.hasClass("exit")).toBeTruthy();
+      expect(status.text("退")).toBeTruthy();
     });
   });
 });

--- a/test/client/components/Participant/__snapshots__/ListBody.spec.jsx.snap
+++ b/test/client/components/Participant/__snapshots__/ListBody.spec.jsx.snap
@@ -14,7 +14,7 @@ exports[`Participant.ListBody.jsxのテスト スナップショット 正しい
         name1
       </div>
       <div
-        className="columnPurpose study border"
+        className="columnPurpose border study"
       >
         自習
       </div>
@@ -33,7 +33,7 @@ exports[`Participant.ListBody.jsxのテスト スナップショット 正しい
         name2
       </div>
       <div
-        className="columnPurpose study border"
+        className="columnPurpose border study"
       >
         自習
       </div>
@@ -52,7 +52,7 @@ exports[`Participant.ListBody.jsxのテスト スナップショット 正しい
         name3
       </div>
       <div
-        className="columnPurpose study border"
+        className="columnPurpose border study"
       >
         自習
       </div>
@@ -71,7 +71,7 @@ exports[`Participant.ListBody.jsxのテスト スナップショット 正しい
         name4
       </div>
       <div
-        className="columnPurpose study border"
+        className="columnPurpose border study"
       >
         自習
       </div>
@@ -90,7 +90,7 @@ exports[`Participant.ListBody.jsxのテスト スナップショット 正しい
         name5
       </div>
       <div
-        className="columnPurpose study border"
+        className="columnPurpose border study"
       >
         自習
       </div>

--- a/test/client/components/Participant/__snapshots__/Purpose.spec.jsx.snap
+++ b/test/client/components/Participant/__snapshots__/Purpose.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Participant.Purpose.jsxのテスト スナップショット 正しいレンダリング 1`] = `
 <div
-  className="columnPurpose study border"
+  className="columnPurpose border study"
 >
   自習
 </div>

--- a/test/client/components/Participant/__snapshots__/index.spec.jsx.snap
+++ b/test/client/components/Participant/__snapshots__/index.spec.jsx.snap
@@ -39,7 +39,7 @@ exports[`Participantのテスト スナップショット 正しいレンダリ�
             name1
           </div>
           <div
-            className="columnPurpose study border"
+            className="columnPurpose border study"
           >
             自習
           </div>
@@ -58,7 +58,7 @@ exports[`Participantのテスト スナップショット 正しいレンダリ�
             name2
           </div>
           <div
-            className="columnPurpose study border"
+            className="columnPurpose border study"
           >
             自習
           </div>
@@ -77,7 +77,7 @@ exports[`Participantのテスト スナップショット 正しいレンダリ�
             name3
           </div>
           <div
-            className="columnPurpose study border"
+            className="columnPurpose border study"
           >
             自習
           </div>
@@ -96,7 +96,7 @@ exports[`Participantのテスト スナップショット 正しいレンダリ�
             name4
           </div>
           <div
-            className="columnPurpose study border"
+            className="columnPurpose border study"
           >
             自習
           </div>
@@ -115,7 +115,7 @@ exports[`Participantのテスト スナップショット 正しいレンダリ�
             name5
           </div>
           <div
-            className="columnPurpose study border"
+            className="columnPurpose border study"
           >
             自習
           </div>

--- a/test/client/components/Participant/index.spec.jsx
+++ b/test/client/components/Participant/index.spec.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
 import Participant from "@components/Participant";
-import ListHeader from "@components/Participant/ListHeader";
-import ListBody from "@components/Participant/ListBody";
 import { shortParticipantData } from "../testData";
 
 describe("Participantのテスト", () => {
@@ -17,23 +15,11 @@ describe("Participantのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    const participant = shallow(<Participant data={shortParticipantData} />);
-    it("cssクラス: flameをもつ", () => {
-      expect(participant.hasClass("flame")).toBeTruthy();
-    });
-
-    it("childrenは、cssクラス: listをもつ", () => {
-      expect(participant.children().hasClass("list")).toBeTruthy();
-    });
-
-    it("ListHeaderコンポーネントを使用している", () => {
-      expect(participant.contains(<ListHeader />)).toBeTruthy();
-    });
-
-    it("ListBodyコンポーネントのlistDataに、shortParticipantDataを渡している", () => {
-      expect(
-        participant.contains(<ListBody listData={shortParticipantData} />)
-      ).toBeTruthy();
+    it("ListBodyコンポーネントのlistDataに、dataで指定した値が渡されている", () => {
+      const participant = shallow(<Participant data={shortParticipantData} />);
+      expect(participant.find("ListBody").prop("listData")).toBe(
+        shortParticipantData
+      );
     });
   });
 });

--- a/test/client/components/Purpose/index.spec.jsx
+++ b/test/client/components/Purpose/index.spec.jsx
@@ -35,82 +35,24 @@ describe("Purpose.jsx", () => {
       />
     );
 
-    it("cssクラス: containerをもつ", () => {
-      expect(purpose.hasClass("container")).toBeTruthy();
+    it("勉強会をクリックしたら、onClickに渡した関数が実行される", () => {
+      purpose.find(".meetUp").simulate("click");
+      expect(mockMeetUpButtonClick).toBeCalled();
     });
 
-    describe("子要素", () => {
-      const children = purpose.children();
+    it("仕事をクリックしたら、onClickに渡した関数が実行される", () => {
+      purpose.find(".work").simulate("click");
+      expect(mockWorkButtonClick).toBeCalled();
+    });
 
-      it("子要素に4つのbutton要素と1つのdiv要素をもつ", () => {
-        expect(children).toHaveLength(5);
-        expect(children.find("button")).toHaveLength(4);
-        expect(children.find("div")).toHaveLength(1);
-      });
+    it("自習をクリックしたら、onClickに渡した関数が実行される", () => {
+      purpose.find(".study").simulate("click");
+      expect(mockStudyButtonClick).toBeCalled();
+    });
 
-      describe("1つ目のbuuton要素", () => {
-        const meetUpButton = children.find("button").at(0);
-
-        it("cssクラス: meetUpをもち、[勉強会]と表示される", () => {
-          expect(meetUpButton.hasClass("meetUp")).toBeTruthy();
-          expect(meetUpButton.text()).toBe("勉強会");
-        });
-
-        it("クリックすると、onMeetUpButtonClickに渡した関数が実行される", () => {
-          meetUpButton.simulate("click");
-          expect(mockMeetUpButtonClick).toBeCalled();
-        });
-      });
-
-      describe("2つ目のbuuton要素", () => {
-        const workButton = children.find("button").at(1);
-
-        it("cssクラス: workをもち、[仕事]と表示される", () => {
-          expect(workButton.hasClass("work")).toBeTruthy();
-          expect(workButton.text()).toBe("仕事");
-        });
-
-        it("クリックすると、onWorkButtonClickに渡した関数が実行される", () => {
-          workButton.simulate("click");
-          expect(mockWorkButtonClick).toBeCalled();
-        });
-      });
-
-      describe("3つ目のbuuton要素", () => {
-        const studyButton = children.find("button").at(2);
-
-        it("cssクラス: studyをもち、[自習]と表示される", () => {
-          expect(studyButton.hasClass("study")).toBeTruthy();
-          expect(studyButton.text()).toBe("自習");
-        });
-
-        it("クリックすると、onStudyButtonClickに渡した関数が実行される", () => {
-          studyButton.simulate("click");
-          expect(mockStudyButtonClick).toBeCalled();
-        });
-      });
-
-      describe("4つ目のbuuton要素", () => {
-        const circleButton = children.find("button").at(3);
-
-        it("cssクラス: circleをもち、[サークル]と表示される", () => {
-          expect(circleButton.hasClass("circle")).toBeTruthy();
-          expect(circleButton.text()).toBe("サークル");
-        });
-
-        it("クリックすると、onMeetUpButtonClickに渡した関数が実行される", () => {
-          circleButton.simulate("click");
-          expect(mockCircleButtonClick).toBeCalled();
-        });
-      });
-
-      describe("div要素", () => {
-        it("cssクラス: messageをもち、[目的を選択して下さい]と表示される", () => {
-          const div = children.find("div");
-          expect(div.hasClass("message")).toBeTruthy();
-          expect(div.text()).toBe("目的を選択して下さい");
-        });
-      });
+    it("サークルをクリックしたら、onClickに渡した関数が実行される", () => {
+      purpose.find(".circle").simulate("click");
+      expect(mockCircleButtonClick).toBeCalled();
     });
   });
 });

--- a/test/client/components/Register/Header.spec.jsx
+++ b/test/client/components/Register/Header.spec.jsx
@@ -12,42 +12,18 @@ describe("Register.Header.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    const base = shallow(<Header current="input" />);
-    const baseListItems = base.find("li");
-
-    it("ol要素はcssクラス: headerをもつ", () => {
-      expect(base.name()).toBe("ol");
-      expect(base.hasClass("header")).toBeTruthy();
-    });
-
-    it("ol要素はli要素を3つ持つ", () => {
-      expect(baseListItems).toHaveLength(3);
-    });
-
-    it("li要素の0番目の子要素は、[1. 入力>]と表示される", () => {
-      expect(baseListItems.at(0).text()).toBe("1. 入力>");
-    });
-
-    it("li要素の1番目の子要素は、[2. 読取>]と表示される", () => {
-      expect(baseListItems.at(1).text()).toBe("2. 読取>");
-    });
-
-    it("li要素の2番目の子要素は、[3. 完了]と表示される", () => {
-      expect(baseListItems.at(2).text()).toBe("3. 完了");
-    });
-
     describe("currentにinputを指定した時", () => {
       const selectedInput = shallow(<Header current="input" />).find("li");
 
-      it("li要素の0番目の子要素は、cssクラス: activeをもつ", () => {
+      it("li要素の0番目の子要素は、cssクラス: activeを持つ", () => {
         expect(selectedInput.at(0).hasClass("active")).toBeTruthy();
       });
 
-      it("li要素の1番目の子要素は、cssクラス: disabledをもつ", () => {
+      it("li要素の1番目の子要素は、cssクラス: disabledを持つ", () => {
         expect(selectedInput.at(1).hasClass("disabled")).toBeTruthy();
       });
 
-      it("li要素の2番目の子要素は、cssクラス: disabledをもつ", () => {
+      it("li要素の2番目の子要素は、cssクラス: disabledを持つ", () => {
         expect(selectedInput.at(2).hasClass("disabled")).toBeTruthy();
       });
     });
@@ -55,21 +31,15 @@ describe("Register.Header.jsxのテスト", () => {
     describe("currentにscanを指定した時", () => {
       const selectedScan = shallow(<Header current="scan" />).find("li");
 
-      it("li要素の0番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
-        expect(
-          Object.prototype.hasOwnProperty.call(
-            selectedScan.at(0).props(),
-            "className"
-          )
-        ).toBeTruthy();
+      it("li要素の0番目の子要素は、クラスを持たない(classNameは、undifined)", () => {
         expect(selectedScan.at(0).props().className).toBeUndefined();
       });
 
-      it("li要素の1番目の子要素は、cssクラス: activeをもつ", () => {
+      it("li要素の1番目の子要素は、cssクラス: activeを持つ", () => {
         expect(selectedScan.at(1).hasClass("active")).toBeTruthy();
       });
 
-      it("li要素の2番目の子要素は、cssクラス: disabledをもつ", () => {
+      it("li要素の2番目の子要素は、cssクラス: disabledを持つ", () => {
         expect(selectedScan.at(2).hasClass("disabled")).toBeTruthy();
       });
     });
@@ -79,21 +49,15 @@ describe("Register.Header.jsxのテスト", () => {
         "li"
       );
 
-      it("li要素の0番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
-        expect(
-          Object.prototype.hasOwnProperty.call(
-            selectedScan.at(0).props(),
-            "className"
-          )
-        ).toBeTruthy();
+      it("li要素の0番目の子要素は、クラスを持たない(classNameは、undifined)", () => {
         expect(selectedScan.at(0).props().className).toBeUndefined();
       });
 
-      it("li要素の1番目の子要素は、cssクラス: activeをもつ", () => {
+      it("li要素の1番目の子要素は、cssクラス: activeを持つ", () => {
         expect(selectedScan.at(1).hasClass("active")).toBeTruthy();
       });
 
-      it("li要素の2番目の子要素は、cssクラス: disabledをもつ", () => {
+      it("li要素の2番目の子要素は、cssクラス: disabledを持つ", () => {
         expect(selectedScan.at(2).hasClass("disabled")).toBeTruthy();
       });
     });
@@ -101,15 +65,15 @@ describe("Register.Header.jsxのテスト", () => {
     describe("currentにfailedを指定した時", () => {
       const selectedInput = shallow(<Header current="failed" />).find("li");
 
-      it("li要素の0番目の子要素は、cssクラス: activeをもつ", () => {
+      it("li要素の0番目の子要素は、cssクラス: activeを持つ", () => {
         expect(selectedInput.at(0).hasClass("disabled")).toBeTruthy();
       });
 
-      it("li要素の1番目の子要素は、cssクラス: disabledをもつ", () => {
+      it("li要素の1番目の子要素は、cssクラス: disabledを持つ", () => {
         expect(selectedInput.at(1).hasClass("disabled")).toBeTruthy();
       });
 
-      it("li要素の2番目の子要素は、cssクラス: disabledをもつ", () => {
+      it("li要素の2番目の子要素は、cssクラス: disabledを持つ", () => {
         expect(selectedInput.at(2).hasClass("disabled")).toBeTruthy();
       });
     });
@@ -119,27 +83,15 @@ describe("Register.Header.jsxのテスト", () => {
         "li"
       );
 
-      it("li要素の0番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
-        expect(
-          Object.prototype.hasOwnProperty.call(
-            selectedCompletion.at(0).props(),
-            "className"
-          )
-        ).toBeTruthy();
+      it("li要素の0番目の子要素は、クラスを持たない(classNameは、undifined)", () => {
         expect(selectedCompletion.at(0).props().className).toBeUndefined();
       });
 
-      it("li要素の1番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
-        expect(
-          Object.prototype.hasOwnProperty.call(
-            selectedCompletion.at(1).props(),
-            "className"
-          )
-        ).toBeTruthy();
+      it("li要素の1番目の子要素は、クラスを持たない(classNameは、undifined)", () => {
         expect(selectedCompletion.at(1).props().className).toBeUndefined();
       });
 
-      it("li要素の2番目の子要素は、cssクラス: activeをもつ", () => {
+      it("li要素の2番目の子要素は、cssクラス: activeを持つ", () => {
         expect(selectedCompletion.at(2).hasClass("active")).toBeTruthy();
       });
     });
@@ -147,33 +99,15 @@ describe("Register.Header.jsxのテスト", () => {
     describe("currentに値を指定しなかった時", () => {
       const selectedCompletion = shallow(<Header />).find("li");
 
-      it("li要素の0番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
-        expect(
-          Object.prototype.hasOwnProperty.call(
-            selectedCompletion.at(0).props(),
-            "className"
-          )
-        ).toBeTruthy();
+      it("li要素の0番目の子要素は、クラスを持たない(classNameは、undifined)", () => {
         expect(selectedCompletion.at(0).props().className).toBeUndefined();
       });
 
-      it("li要素の1番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
-        expect(
-          Object.prototype.hasOwnProperty.call(
-            selectedCompletion.at(1).props(),
-            "className"
-          )
-        ).toBeTruthy();
+      it("li要素の1番目の子要素は、クラスを持たない(classNameは、undifined)", () => {
         expect(selectedCompletion.at(1).props().className).toBeUndefined();
       });
 
-      it("li要素の2番目の子要素は、クラスをもたない(classNameは、undifined)", () => {
-        expect(
-          Object.prototype.hasOwnProperty.call(
-            selectedCompletion.at(2).props(),
-            "className"
-          )
-        ).toBeTruthy();
+      it("li要素の2番目の子要素は、クラスを持たない(classNameは、undifined)", () => {
         expect(selectedCompletion.at(2).props().className).toBeUndefined();
       });
     });

--- a/test/client/components/Register/Input.spec.jsx
+++ b/test/client/components/Register/Input.spec.jsx
@@ -31,34 +31,15 @@ describe("Register.Input.jsxのテスト", () => {
       />
     );
 
-    it("idに指定された値が、input要素のidに指定されている", () => {
-      expect(input.find("input").props().id).toBe("id");
+    it("label要素のhtmlForに、idで指定された値が渡されている", () => {
+      expect(input.find("label").prop("htmlFor")).toBe("id");
     });
 
-    it("labelに指定された値が、ラベルとして表示されている", () => {
+    it("label要素に、labelで指定された値が表示されている", () => {
       expect(input.find("label").text()).toBe("ラベル");
     });
 
-    it("valueに指定された値が、inputに入力されている", () => {
-      expect(input.find("input").props().value).toBe("value");
-    });
-
-    it("inputの内容が変更されたとき、onChangeに指定した関数が呼ばれる", () => {
-      input.find("input").simulate("change", "test");
-      expect(mockChange.mock.calls[0][0]).toBe("test");
-    });
-
-    describe("errorに空文字が指定されている時", () => {
-      it("エラーメッセージは表示されない", () => {
-        expect(input.find(".message").text()).toBe("");
-      });
-
-      it("input要素はcssクラス: inputをもつ", () => {
-        expect(input.find("input").hasClass("input")).toBeTruthy();
-      });
-    });
-
-    describe("errorに空文字以外が指定されている時", () => {
+    it("errorが1文字以上の時、エラーが表示される", () => {
       const badInput = shallow(
         <Input
           id="id"
@@ -68,14 +49,26 @@ describe("Register.Input.jsxのテスト", () => {
           onChange={mockChange}
         />
       );
+      expect(badInput.find(".message").text()).toBe("error");
+      expect(badInput.find("input").hasClass("bad")).toBeTruthy();
+    });
 
-      it("エラーメッセージとして表示される", () => {
-        expect(badInput.find(".message").text()).toBe("error");
-      });
+    it("errorが0文字の時、エラーは表示されない", () => {
+      expect(input.find(".message").text()).toBe("");
+      expect(input.find("input").hasClass("bad")).toBeFalsy();
+    });
 
-      it("input要素はcssクラス: inputとbadをもつ", () => {
-        expect(badInput.find("input").hasClass("input bad")).toBeTruthy();
-      });
+    it("input要素のidに、idに指定された値が渡されている", () => {
+      expect(input.find("input").prop("id")).toBe("id");
+    });
+
+    it("input要素に、valueで指定された値が入力されている", () => {
+      expect(input.find("input").prop("value")).toBe("value");
+    });
+
+    it("input要素の内容が変更された時、onChangeに指定した関数が呼ばれる", () => {
+      input.find("input").simulate("change", "test");
+      expect(mockChange.mock.calls[0][0]).toBe("test");
     });
   });
 });

--- a/test/client/components/Register/RegisterFailed.spec.jsx
+++ b/test/client/components/Register/RegisterFailed.spec.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow, mount } from "enzyme";
+import { shallow } from "enzyme";
 import RegisterFailed from "@components/Register/RegisterFailed";
 
 describe("RegisterFailed.jsxのテスト", () => {
@@ -12,50 +12,12 @@ describe("RegisterFailed.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    const onButton = () => {};
-    const scan = shallow(<RegisterFailed onBackButton={onButton} />);
-
-    it("cssクラス: mainをもつ", () => {
-      expect(scan.hasClass("main")).toBeTruthy();
-    });
-
-    it("子要素のdivは、cssクラス: contentWithButtonとtextOnlyをもつ", () => {
-      expect(
-        scan
-          .children()
-          .find("div")
-          .hasClass("contentWithButton")
-      ).toBeTruthy();
-      expect(
-        scan
-          .children()
-          .find("div")
-          .hasClass("textOnly")
-      ).toBeTruthy();
-    });
-
-    it("「登録に失敗しました」と表示されている", () => {
-      expect(
-        scan
-          .children()
-          .find("div")
-          .text()
-      ).toBe("登録に失敗しました");
-    });
-
-    it("子要素のSingleButtonに、値を渡している", () => {
-      expect(scan.find("SingleButton").prop("text")).toBe("入力画面に戻る");
-      expect(scan.find("SingleButton").prop("className")).toBe("default");
-      expect(scan.find("SingleButton").prop("onButtonClick")).toBe(onButton);
-    });
-
-    describe("SingleButtonをクリックした時", () => {
-      it("onCancelButtonに渡した関数が呼び出される", () => {
-        const mock = jest.fn();
-        const fullDom = mount(<RegisterFailed onBackButton={mock} />);
-        fullDom.find("SingleButton button").simulate("click");
-        expect(mock).toBeCalled();
-      });
+    it("SingleButtonのonButtonClickに、onBackButtonで指定された関数が渡されている", () => {
+      const fn = () => {};
+      const registerFailed = shallow(<RegisterFailed onBackButton={fn} />);
+      expect(registerFailed.find("SingleButton").prop("onButtonClick")).toBe(
+        fn
+      );
     });
   });
 });

--- a/test/client/components/Register/RegisterInput.spec.jsx
+++ b/test/client/components/Register/RegisterInput.spec.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow, mount } from "enzyme";
+import { shallow } from "enzyme";
 import RegisterInput from "@components/Register/RegisterInput";
 
 describe("RegisterInput.jsxのテスト", () => {
@@ -27,201 +27,117 @@ describe("RegisterInput.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
+    delete process.env.E_MAIL_DOMAIN;
+    /**
+     * testする内容
+     * - propsに指定された値, 関数が想定通りに表示されている、渡されている
+     */
     const onFirstNameChange = () => {};
     const onLastNameChange = () => {};
     const onEmailChange = () => {};
-    const onClickNextButton = jest.fn();
+    const onClickNextButton = () => {};
     const submitFunc = jest.fn();
-    const stantardInput = shallow(
+
+    const registerInput = shallow(
       <RegisterInput
+        firstNameError="firstNameError"
         firstNameValue="firstName"
-        firstNameError=""
-        lastNameValue="lastName"
-        lastNameError=""
-        emailValue="email"
-        emailError=""
         onFirstNameChange={onFirstNameChange}
+        lastNameError="lastNameError"
+        lastNameValue="lastName"
         onLastNameChange={onLastNameChange}
+        emailError="emailError"
+        emailValue="email"
         onEmailChange={onEmailChange}
         onClickNextButton={onClickNextButton}
         onSubmitForm={submitFunc}
       />
     );
 
-    it("cssクラス: mainをもつ", () => {
-      expect(stantardInput.hasClass("main")).toBeTruthy();
+    it("form要素のonSubmitに、onSubmitFormに指定した関数を渡している", () => {
+      expect(registerInput.find("form").prop("onSubmit")).toBe(submitFunc);
     });
 
-    it("form要素のonSubmitに関数を渡している", () => {
-      expect(stantardInput.find("form").prop("onSubmit")).toBe(submitFunc);
-    });
+    describe("Inputコンポーネント(firstName)", () => {
+      const firstName = registerInput.find("#firstName");
 
-    it("form要素の子要素divは、cssクラス: contentWithButtonをもつ", () => {
-      expect(
-        stantardInput.find("form > div").hasClass("contentWithButton")
-      ).toBeTruthy();
-    });
+      it("errorに、firstNameErrorで指定された値が渡されている", () => {
+        expect(firstName.prop("error")).toBe("firstNameError");
+      });
 
-    it("form要素の子要素divは、2つのdiv要素をもつ", () => {
-      expect(stantardInput.find("form > div").children()).toHaveLength(2);
-    });
+      it("valueに、firstNameValueで指定された値が渡されている", () => {
+        expect(firstName.prop("value")).toBe("firstName");
+      });
 
-    it("2つのdiv要素の1つ目は、cssクラス: inputNameをもつ", () => {
-      expect(
-        stantardInput
-          .find("form > div")
-          .childAt(0)
-          .hasClass("inputName")
-      ).toBeTruthy();
-    });
-
-    it("2つのdiv要素の2つ目は、cssクラス: inputEmailをもつ", () => {
-      expect(
-        stantardInput
-          .find("form > div")
-          .childAt(1)
-          .hasClass("inputEmail")
-      ).toBeTruthy();
-    });
-
-    it("2つのdiv要素の2つ目は、cssクラス: domainをもつspan要素をもつ", () => {
-      const span = stantardInput
-        .find("form > div")
-        .childAt(1)
-        .find("span");
-
-      expect(span).toHaveLength(1);
-      expect(span.hasClass("domain")).toBeTruthy();
-    });
-
-    it("form要素はInputコンポーネントを3つもつ", () => {
-      expect(stantardInput.find("Input")).toHaveLength(3);
-    });
-
-    it("1つ目のInputコンポーネントにfirstNameの情報を渡している", () => {
-      const { id, label, error, value, onChange } = stantardInput
-        .find("Input")
-        .at(0)
-        .props();
-
-      expect(id).toBe("firstName");
-      expect(label).toBe("姓");
-      expect(error).toBe("");
-      expect(value).toBe("firstName");
-      expect(onChange).toBe(onFirstNameChange);
-    });
-
-    it("2つ目のInputコンポーネントにlastNameの情報を渡している", () => {
-      const { id, label, error, value, onChange } = stantardInput
-        .find("Input")
-        .at(1)
-        .props();
-
-      expect(id).toBe("lastName");
-      expect(label).toBe("名");
-      expect(error).toBe("");
-      expect(value).toBe("lastName");
-      expect(onChange).toBe(onLastNameChange);
-    });
-
-    it("3つ目のInputコンポーネントにemailの情報を渡している", () => {
-      const { id, label, error, value, onChange } = stantardInput
-        .find("Input")
-        .at(2)
-        .props();
-
-      expect(id).toBe("email");
-      expect(label).toBe("Email");
-      expect(error).toBe("");
-      expect(value).toBe("email");
-      expect(onChange).toBe(onEmailChange);
-    });
-
-    it("form要素はSingleButtonコンポーネントを1つもつ", () => {
-      expect(stantardInput.find("SingleButton")).toHaveLength(1);
-    });
-
-    it("SingleButtonコンポーネントに必要な情報を渡している", () => {
-      const { text, className, onButtonClick } = stantardInput
-        .find("SingleButton")
-        .props();
-
-      expect(text).toBe("次へ");
-      expect(className).toBe("next");
-      expect(onButtonClick).toBe(onClickNextButton);
-    });
-
-    describe("process.env.E_MAIL_DOMAINが設定されていない時", () => {
-      it("メールアドレスのドメイン名は、デフォルト値", () => {
-        delete process.env.E_MAIL_DOMAIN;
-        const defaultDomainInput = shallow(
-          <RegisterInput
-            firstNameValue="firstName"
-            firstNameError=""
-            lastNameValue="lastName"
-            lastNameError=""
-            emailValue="email"
-            emailError=""
-            onFirstNameChange={onFirstNameChange}
-            onLastNameChange={onLastNameChange}
-            onEmailChange={onEmailChange}
-            onClickNextButton={onClickNextButton}
-            onSubmitForm={submitFunc}
-          />
-        );
-        expect(defaultDomainInput.find("span").text()).toBe("@hoge.com");
+      it("onChangeに、onFirstNameChangeで指定された関数が渡されている", () => {
+        expect(firstName.prop("onChange")).toBe(onFirstNameChange);
       });
     });
 
-    describe("process.env.E_MAIL_DOMAINが設定されてる時", () => {
-      it("メールアドレスのドメイン名は、設定された値", () => {
+    describe("Inputコンポーネント(lastName)", () => {
+      const lastName = registerInput.find("#lastName");
+
+      it("errorに、lastNameErrorで指定された値が渡されている", () => {
+        expect(lastName.prop("error")).toBe("lastNameError");
+      });
+
+      it("valueに、lastNameValueで指定された値が渡されている", () => {
+        expect(lastName.prop("value")).toBe("lastName");
+      });
+
+      it("onChangeに、onLastNameChangeで指定された関数が渡されている", () => {
+        expect(lastName.prop("onChange")).toBe(onLastNameChange);
+      });
+    });
+
+    describe("Inputコンポーネント(email)", () => {
+      const email = registerInput.find("#email");
+
+      it("errorに、emailErrorで指定された値が渡されている", () => {
+        expect(email.prop("error")).toBe("emailError");
+      });
+
+      it("valueに、emailValueで指定された値が渡されている", () => {
+        expect(email.prop("value")).toBe("email");
+      });
+
+      it("onChangeに、onEmailChangeで指定された関数が渡されている", () => {
+        expect(email.prop("onChange")).toBe(onEmailChange);
+      });
+
+      it("process.env.E_MAIL_DOMAINが設定されていない時、デフォルト値が表示される", () => {
+        expect(registerInput.find(".domain").text()).toBe("@hoge.com");
+      });
+
+      it("process.env.E_MAIL_DOMAINが設定されている時、設定された値が表示される", () => {
         process.env.E_MAIL_DOMAIN = "test.com";
-        const customDomainInput = shallow(
+
+        const fn = () => {};
+        const domain = shallow(
           <RegisterInput
-            firstNameValue="firstName"
             firstNameError=""
-            lastNameValue="lastName"
+            firstNameValue=""
+            onFirstNameChange={fn}
             lastNameError=""
-            emailValue="email"
+            lastNameValue=""
+            onLastNameChange={fn}
             emailError=""
-            onFirstNameChange={onFirstNameChange}
-            onLastNameChange={onLastNameChange}
-            onEmailChange={onEmailChange}
-            onClickNextButton={onClickNextButton}
-            onSubmitForm={submitFunc}
+            emailValue=""
+            onEmailChange={fn}
+            onClickNextButton={fn}
+            onSubmitForm={fn}
           />
-        );
-        expect(customDomainInput.find("span").text()).toBe("@test.com");
+        )
+          .find(".domain")
+          .text();
+
+        expect(domain).toBe("@test.com");
       });
     });
 
-    describe("SingleButtonをクリックした時", () => {
-      it("form要素のonSubmitに渡した関数が呼ばれる", () => {
-        const fullDom = mount(
-          <RegisterInput
-            firstNameValue="firstName"
-            firstNameError=""
-            lastNameValue="lastName"
-            lastNameError=""
-            emailValue="email"
-            emailError=""
-            onFirstNameChange={onFirstNameChange}
-            onLastNameChange={onLastNameChange}
-            onEmailChange={onEmailChange}
-            onClickNextButton={onClickNextButton}
-            onSubmitForm={submitFunc}
-          />
-        );
-        // クリック
-        fullDom
-          .find("SingleButton")
-          .find("button")
-          .simulate("click");
-        expect(onClickNextButton).toBeCalled();
-        // submit(ブラウザと違うため明示的にsubmit操作を行う)
-        fullDom.find("form").simulate("submit");
-        expect(submitFunc).toBeCalled();
-      });
+    it("SingleButtonをクリックした時、form要素のonSubmitに渡した関数が呼ばれる", () => {
+      registerInput.find("form").simulate("submit");
+      expect(submitFunc).toBeCalled();
     });
   });
 });

--- a/test/client/components/Register/RegisterScan.spec.jsx
+++ b/test/client/components/Register/RegisterScan.spec.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow, mount } from "enzyme";
+import { shallow } from "enzyme";
 import RegisterScan from "@components/Register/RegisterScan";
 
 describe("RegisterScan.jsxのテスト", () => {
@@ -12,50 +12,10 @@ describe("RegisterScan.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    const onButton = () => {};
-    const scan = shallow(<RegisterScan onCancelButton={onButton} />);
-
-    it("cssクラス: mainをもつ", () => {
-      expect(scan.hasClass("main")).toBeTruthy();
-    });
-
-    it("子要素のdivは、cssクラス: contentWithButtonとtextOnlyをもつ", () => {
-      expect(
-        scan
-          .children()
-          .find("div")
-          .hasClass("contentWithButton")
-      ).toBeTruthy();
-      expect(
-        scan
-          .children()
-          .find("div")
-          .hasClass("textOnly")
-      ).toBeTruthy();
-    });
-
-    it("「カードをスキャンして下さい」と表示されている", () => {
-      expect(
-        scan
-          .children()
-          .find("div")
-          .text()
-      ).toBe("カードをスキャンして下さい");
-    });
-
-    it("子要素のSingleButtonに、値を渡している", () => {
-      expect(scan.find("SingleButton").prop("text")).toBe("キャンセル");
-      expect(scan.find("SingleButton").prop("className")).toBe("default");
-      expect(scan.find("SingleButton").prop("onButtonClick")).toBe(onButton);
-    });
-
-    describe("SingleButtonをクリックした時", () => {
-      it("onCancelButtonに渡した関数が呼び出される", () => {
-        const mock = jest.fn();
-        const fullDom = mount(<RegisterScan onCancelButton={mock} />);
-        fullDom.find("SingleButton button").simulate("click");
-        expect(mock).toBeCalled();
-      });
+    it("SingleButtonのonButtonClickに、onCancelButtonで指定した関数が渡されている", () => {
+      const fn = () => {};
+      const registerScan = shallow(<RegisterScan onCancelButton={fn} />);
+      expect(registerScan.find("SingleButton").prop("onButtonClick")).toBe(fn);
     });
   });
 });

--- a/test/client/components/Register/RegisterSuccess.spec.jsx
+++ b/test/client/components/Register/RegisterSuccess.spec.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow, mount } from "enzyme";
+import { shallow } from "enzyme";
 import RegisterSuccess from "@components/Register/RegisterSuccess";
 
 describe("RegisterSuccess.jsxのテスト", () => {
@@ -14,50 +14,10 @@ describe("RegisterSuccess.jsxのテスト", () => {
   });
 
   describe("コンポーネントのテスト", () => {
-    const onButton = () => {};
-    const scan = shallow(<RegisterSuccess onEntryButton={onButton} />);
-
-    it("cssクラス: mainをもつ", () => {
-      expect(scan.hasClass("main")).toBeTruthy();
-    });
-
-    it("子要素のdivは、cssクラス: contentWithButtonとtextOnlyをもつ", () => {
-      expect(
-        scan
-          .children()
-          .find("div")
-          .hasClass("contentWithButton")
-      ).toBeTruthy();
-      expect(
-        scan
-          .children()
-          .find("div")
-          .hasClass("textOnly")
-      ).toBeTruthy();
-    });
-
-    it("「登録しました!!」と表示されている", () => {
-      expect(
-        scan
-          .children()
-          .find("div")
-          .text()
-      ).toBe("登録しました!!");
-    });
-
-    it("子要素のSingleButtonに、値を渡している", () => {
-      expect(scan.find("SingleButton").prop("text")).toBe("入室する");
-      expect(scan.find("SingleButton").prop("className")).toBe("next");
-      expect(scan.find("SingleButton").prop("onButtonClick")).toBe(onButton);
-    });
-
-    describe("SingleButtonをクリックした時", () => {
-      it("onCancelButtonに渡した関数が呼び出される", () => {
-        const mock = jest.fn();
-        const fullDom = mount(<RegisterSuccess onEntryButton={mock} />);
-        fullDom.find("SingleButton button").simulate("click");
-        expect(mock).toBeCalled();
-      });
+    it("SingleButtonのonButtonClickに、onEntryButtonで指定した関数が渡されている", () => {
+      const fn = () => {};
+      const registerScan = shallow(<RegisterSuccess onEntryButton={fn} />);
+      expect(registerScan.find("SingleButton").prop("onButtonClick")).toBe(fn);
     });
   });
 });

--- a/test/client/components/Register/RegistrationIn.spec.jsx
+++ b/test/client/components/Register/RegistrationIn.spec.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow } from "enzyme";
 import RegistrationIn from "@components/Register/RegistrationIn";
 
 describe("RegistrationIn.jsxのテスト", () => {
@@ -8,25 +7,6 @@ describe("RegistrationIn.jsxのテスト", () => {
     it("正しいレンダリング", () => {
       const tree = renderer.create(<RegistrationIn />);
       expect(tree).toMatchSnapshot();
-    });
-  });
-
-  describe("コンポーネントのテスト", () => {
-    const registrationIn = shallow(<RegistrationIn />);
-    const div = registrationIn.childAt(0);
-
-    it("cssクラス: mainをもつ", () => {
-      expect(registrationIn.hasClass("main")).toBeTruthy();
-    });
-
-    it("子要素divはcssクラス: content, registrationInをもつ", () => {
-      expect(div.name()).toBe("div");
-      expect(div.hasClass("content")).toBeTruthy();
-      expect(div.hasClass("content")).toBeTruthy();
-    });
-
-    it("登録中と表示される", () => {
-      expect(registrationIn.text()).toBe("登録中");
     });
   });
 });

--- a/test/client/components/SingleButton.spec.jsx
+++ b/test/client/components/SingleButton.spec.jsx
@@ -13,32 +13,26 @@ describe("SingleButton.jsxのテスト", () => {
 
   describe("コンポーネントのテスト", () => {
     const onClick = jest.fn();
-    const defaultButton = shallow(
+    const button = shallow(
       <SingleButton text="Single Button" onButtonClick={onClick} />
-    );
-    const button = defaultButton.find("button");
-    it("cssクラス: singleButtonをもつ", () => {
-      expect(defaultButton.hasClass("singleButton")).toBeTruthy();
-    });
+    ).find("button");
 
-    it("button要素はcssクラス: defaultをもつ", () => {
+    it("classNameを指定しない時、button要素はcssクラス: defaultをもつ", () => {
       expect(button.hasClass("default")).toBeTruthy();
     });
 
-    it("textに渡した文字列が表示される", () => {
+    it("classNameにnextと指定した時、button要素はcssクラス: nextをもつ", () => {
+      const nextButton = shallow(<SingleButton className="next" />);
+      expect(nextButton.find("button").hasClass("next")).toBeTruthy();
+    });
+
+    it("textに渡した値が、文表示される", () => {
       expect(button.text("Single Button")).toBeTruthy();
     });
 
-    it("クリックすると、onButtonClickに渡した関数が実行される", () => {
+    it("ボタンをクリックすると、onButtonClickに渡した関数が実行される", () => {
       button.simulate("click");
       expect(onClick).toBeCalled();
-    });
-
-    describe("classNameにnextと指定した時", () => {
-      it("button要素はcssクラス: nextをもつ", () => {
-        const nextButton = shallow(<SingleButton className="next" />);
-        expect(nextButton.find("button").hasClass("next")).toBeTruthy();
-      });
     });
   });
 });

--- a/test/client/components/Top.spec.jsx
+++ b/test/client/components/Top.spec.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { shallow } from "enzyme";
 import Top from "@components/Top";
 
 describe("Top.jsxのテスト", () => {
@@ -8,34 +7,6 @@ describe("Top.jsxのテスト", () => {
     it("正しいレンダリング", () => {
       const tree = renderer.create(<Top />);
       expect(tree).toMatchSnapshot();
-    });
-  });
-
-  describe("コンポーネントのテスト", () => {
-    const top = shallow(<Top />);
-
-    it("cssクラス: topをもつ", () => {
-      expect(top.hasClass("top")).toBeTruthy();
-    });
-
-    it("子要素としてdivを2つもつ", () => {
-      expect(top.children()).toHaveLength(2);
-    });
-
-    describe("1つ目の子要素", () => {
-      it("「カードをスキャンして下さい」と表示される", () => {
-        expect(top.childAt(0).text()).toBe("カードをスキャンして下さい");
-      });
-    });
-
-    describe("2つ目の子要素", () => {
-      it("「Created by hr-js」と表示される", () => {
-        expect(top.childAt(1).text()).toBe("Created by hr-js");
-      });
-
-      it("cssクラス: labelをもつ", () => {
-        expect(top.childAt(1).hasClass("label")).toBeTruthy();
-      });
     });
   });
 });

--- a/test/client/components/__snapshots__/Common.spec.jsx.snap
+++ b/test/client/components/__snapshots__/Common.spec.jsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Common.jsxのテスト スナップショット 正しいレンダリング 1`] = `
+<div>
+  <div
+    className="textArea"
+  >
+    <div
+      className="main"
+    >
+      テキスト
+    </div>
+    <div
+      className="date"
+    >
+      1970/01/01 00:00:00
+    </div>
+    <div
+      className="sub"
+    >
+      サブテキスト
+    </div>
+  </div>
+  <div
+    className="singleButton"
+  >
+    <button
+      className="default"
+      onClick={[Function]}
+    >
+      ボタン
+    </button>
+  </div>
+</div>
+`;

--- a/test/client/components/__snapshots__/MainFlame.spec.jsx.snap
+++ b/test/client/components/__snapshots__/MainFlame.spec.jsx.snap
@@ -7,9 +7,7 @@ exports[`MainFlame.jsxのテスト スナップショット 正しいレンダ�
   <div
     className="main"
   >
-    <div>
-      test component
-    </div>
+    children
   </div>
 </main>
 `;


### PR DESCRIPTION
## 関連issue
入退室処理画面コンポーネント作成 #107

## 変更点
- ボタンのoutlineをnoneに設定し、forcus時に表示される枠を非表示にした